### PR TITLE
update link for nativescript angular UI overview page

### DIFF
--- a/src/docs/development/frameworks-mobile/nativescript.md
+++ b/src/docs/development/frameworks-mobile/nativescript.md
@@ -43,7 +43,7 @@ Sidekick allows you to get around network issues and hardware requirements by of
 
 ## Component recommendations
 Nativescript comes with a diverse library of components out of the box. We also recommend you look at some of the following components if you need to supplement:
-- [Default Components](https://docs.nativescript.org/angular/ui/components)
+- [Default Components](https://docs.nativescript.org/angular/ui/overview)
 - [NB Material](https://github.com/nabil-mansouri/nativescript-nbmaterial) (contains an assortment of supplemental components)
 - [Cards](https://github.com/bradmartin/nativescript-cardview)
 - [Dropdown](https://github.com/PeterStaev/NativeScript-Drop-Down)


### PR DESCRIPTION
Fixes # Broken link found during build process

Changes proposed in this Pull Request:
- nativescript changed url to new overview
- 
- 
