### PR TITLE
update highsoft faq license link

### DIFF
--- a/src/docs/patterns/visualizations.md
+++ b/src/docs/patterns/visualizations.md
@@ -7,7 +7,7 @@ Currently, PX Blue supports building charts and graphs using [Highcharts](http:/
 
 PX Blue utilities for Highcharts graphs (line, column, pie, donut) are available as an NPM package ([@pxblue/highcharts](https://www.npmjs.com/package/@pxblue/highcharts)). This package includes helper functions to generate chart configurations using recommended PX Blue styles. These utilities also enable you to quickly create placeholder charts using simulated data. For more information about using Highcharts, check out their documentation.
 
-> Highcharts has different [licensing](https://shop.highsoft.com/faq/licensing) requirements depending on the nature of your application - you will need to contact Highsoft directly to ensure that your product is properly licensed. You can also see the [Highcharts Pricing](https://shop.highsoft.com/highcharts/) page for pricing information. In the future, we plan to explore additional open-source charting solutions for inclusion in PX Blue.
+> Highcharts has different [licensing](https://shop.highsoft.com/faq) requirements depending on the nature of your application - you will need to contact Highsoft directly to ensure that your product is properly licensed. You can also see the [Highcharts Pricing](https://shop.highsoft.com/highcharts/) page for pricing information. In the future, we plan to explore additional open-source charting solutions for inclusion in PX Blue.
 
 
 {{ angular stackblitz=https://stackblitz.com/edit/pxblue-highcharts-angular?embed=1&file=src/app/app.component.ts&hideNavigation=1&view=preview }}


### PR DESCRIPTION
Fixes # Broken link highsoft

Changes proposed in this Pull Request:
- updated old link with new link for faq license page
- 
- 
