### PR TITLE
Add material design description card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,194 +1,194 @@
 {
-  "name": "doc-it",
-  "author": "PX Blue <pxblue@eaton.com>",
-  "version": "2.4.0",
-  "private": true,
-  "scripts": {
-    "start": "node scripts/start.js",
-    "build": "node scripts/build.js",
-    "test": "node scripts/test.js",
-    "check:links": "bash ./___scripts___/link-check/checklinks.sh",
-    "check:links-ci": "bash ./___scripts___/link-check/checklinksCI.sh",
-    "ga:prod": "cp -r ./config/ga.prod.js ./src/ga.js",
-    "ga:dev": "cp -r ./config/ga.dev.js ./src/ga.js",
-    "lint": "eslint \"src/**/**.{tsx,ts}\"",
-    "lint:fix": "eslint \"src/**/**.{tsx,ts}\" --fix",
-    "prettier": "prettier \"src/**/**.{ts,tsx,js,jsx,json,css,scss,html,mdx}\" --write"
-  },
-  "prettier": "@pxblue/prettier-config",
-  "dependencies": {
-    "@brainhubeu/react-carousel": "^1.12.15",
-    "@material-ui/core": "^4.2.0",
-    "@material-ui/icons": "^4.2.1",
-    "@pxblue/colors": "^2.0.1",
-    "@pxblue/colors-branding": "^3.0.0",
-    "@pxblue/icons-mui": "^2.1.0",
-    "@pxblue/react-components": "^3.0.2",
-    "@pxblue/react-progress-icons": "^2.0.0",
-    "@pxblue/react-themes": "^4.0.0",
-    "axios": "^0.19.2",
-    "clsx": "^1.1.0",
-    "prop-types": "^15.7.2",
-    "react": "^16.12.0",
-    "react-app-polyfill": "^1.0.5",
-    "react-dev-utils": "^10.0.0",
-    "react-dom": "^16.12.0",
-    "react-ga": "^2.7.0",
-    "react-redux": "^7.2.0",
-    "react-router-dom": "^5.1.2",
-    "redux": "^4.0.5"
-  },
-  "devDependencies": {
-    "@babel/core": "7.7.4",
-    "@mdx-js/loader": "^1.5.5",
-    "@mdx-js/react": "^1.5.5",
-    "@pxblue/eslint-config": "^1.1.3",
-    "@pxblue/prettier-config": "^1.0.2",
-    "@svgr/webpack": "4.3.3",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/axios": "^0.14.0",
-    "@types/brainhubeu__react-carousel": "^1.10.2",
-    "@types/enzyme": "^3.10.5",
-    "@types/enzyme-adapter-react-16": "^1.0.6",
-    "@types/jest": "^24.0.0",
-    "@types/mdx-js__react": "^1.5.0",
-    "@types/node": "^12.0.0",
-    "@types/react": "^16.9.0",
-    "@types/react-dom": "^16.9.0",
-    "@types/react-redux": "^7.1.7",
-    "@types/react-router-dom": "^5.1.3",
-    "@typescript-eslint/eslint-plugin": "^2.18.0",
-    "@typescript-eslint/parser": "^2.18.0",
-    "babel-eslint": "10.0.3",
-    "babel-jest": "^24.9.0",
-    "babel-loader": "8.0.6",
-    "babel-plugin-named-asset-import": "^0.3.5",
-    "babel-preset-react-app": "^9.1.0",
-    "camelcase": "^5.3.1",
-    "case-sensitive-paths-webpack-plugin": "2.2.0",
-    "css-loader": "3.2.0",
-    "dotenv": "8.2.0",
-    "dotenv-expand": "5.1.0",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.2",
-    "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
-    "eslint-config-react-app": "^5.1.0",
-    "eslint-loader": "3.0.2",
-    "eslint-plugin-flowtype": "3.13.0",
-    "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-jsx-a11y": "6.2.3",
-    "eslint-plugin-mdx": "^1.6.8",
-    "eslint-plugin-react": "^7.18.0",
-    "eslint-plugin-react-hooks": "^1.6.1",
-    "file-loader": "4.3.0",
-    "fs-extra": "^8.1.0",
-    "html-webpack-plugin": "4.0.0-beta.5",
-    "identity-obj-proxy": "3.0.0",
-    "jest": "24.9.0",
-    "jest-environment-jsdom-fourteen": "0.1.0",
-    "jest-resolve": "24.9.0",
-    "jest-transformer-mdx": "^2.1.0",
-    "jest-watch-typeahead": "0.4.2",
-    "markdown-link-check": "^3.8.0",
-    "mini-css-extract-plugin": "0.8.0",
-    "optimize-css-assets-webpack-plugin": "5.0.3",
-    "pnp-webpack-plugin": "1.5.0",
-    "postcss-flexbugs-fixes": "4.1.0",
-    "postcss-loader": "3.0.0",
-    "postcss-normalize": "8.0.1",
-    "postcss-preset-env": "6.7.0",
-    "postcss-safe-parser": "4.0.1",
-    "prettier": "^1.19.1",
-    "resolve": "1.12.2",
-    "resolve-url-loader": "3.1.1",
-    "sass-loader": "8.0.0",
-    "semver": "6.3.0",
-    "style-loader": "1.0.0",
-    "terser-webpack-plugin": "2.2.1",
-    "ts-pnp": "1.1.5",
-    "typeface-open-sans": "0.0.75",
-    "typeface-roboto-mono": "^0.0.75",
-    "typescript": "~3.7.2",
-    "url-loader": "2.3.0",
-    "webpack": "4.41.2",
-    "webpack-dev-server": "3.9.0",
-    "webpack-manifest-plugin": "2.2.0",
-    "workbox-webpack-plugin": "4.3.1"
-  },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all",
-      "ie 11"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version",
-      "ie 11"
-    ]
-  },
-  "jest": {
-    "roots": [
-      "<rootDir>/src"
-    ],
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx,ts,tsx}",
-      "!src/**/*.d.ts"
-    ],
-    "setupFiles": [
-      "react-app-polyfill/jsdom"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/src/setupTests.ts"
-    ],
-    "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
-    ],
-    "testEnvironment": "jest-environment-jsdom-fourteen",
-    "transform": {
-      "^.+\\.(mdx)$": "jest-transformer-mdx",
-      "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-      "^(?!.*\\.(js|jsx|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
+    "name": "doc-it",
+    "author": "PX Blue <pxblue@eaton.com>",
+    "version": "2.4.0",
+    "private": true,
+    "scripts": {
+        "start": "node scripts/start.js",
+        "build": "node scripts/build.js",
+        "test": "node scripts/test.js",
+        "check:links": "bash ./___scripts___/link-check/checklinks.sh",
+        "check:links-ci": "bash ./___scripts___/link-check/checklinksCI.sh",
+        "ga:prod": "cp -r ./config/ga.prod.js ./src/ga.js",
+        "ga:dev": "cp -r ./config/ga.dev.js ./src/ga.js",
+        "lint": "eslint \"src/**/**.{tsx,ts}\"",
+        "lint:fix": "eslint \"src/**/**.{tsx,ts}\" --fix",
+        "prettier": "prettier \"src/**/**.{ts,tsx,js,jsx,json,css,scss,html,mdx}\" --write"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$",
-      "^.+\\.module\\.(css|sass|scss)$"
-    ],
-    "modulePaths": [],
-    "moduleNameMapper": {
-      "^react-native$": "react-native-web",
-      "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy"
+    "prettier": "@pxblue/prettier-config",
+    "dependencies": {
+        "@brainhubeu/react-carousel": "^1.12.15",
+        "@material-ui/core": "^4.2.0",
+        "@material-ui/icons": "^4.2.1",
+        "@pxblue/colors": "^2.0.1",
+        "@pxblue/colors-branding": "^3.0.0",
+        "@pxblue/icons-mui": "^2.1.0",
+        "@pxblue/react-components": "^3.0.2",
+        "@pxblue/react-progress-icons": "^2.0.0",
+        "@pxblue/react-themes": "^5.0.0-beta.0",
+        "axios": "^0.19.2",
+        "clsx": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "react": "^16.12.0",
+        "react-app-polyfill": "^1.0.5",
+        "react-dev-utils": "^10.0.0",
+        "react-dom": "^16.12.0",
+        "react-ga": "^2.7.0",
+        "react-redux": "^7.2.0",
+        "react-router-dom": "^5.1.2",
+        "redux": "^4.0.5"
     },
-    "moduleFileExtensions": [
-      "web.js",
-      "js",
-      "web.ts",
-      "ts",
-      "web.tsx",
-      "tsx",
-      "json",
-      "web.jsx",
-      "jsx",
-      "node"
-    ],
-    "watchPlugins": [
-      "jest-watch-typeahead/filename",
-      "jest-watch-typeahead/testname"
-    ]
-  },
-  "babel": {
-    "presets": [
-      "react-app"
-    ]
-  }
+    "devDependencies": {
+        "@babel/core": "7.7.4",
+        "@mdx-js/loader": "^1.5.5",
+        "@mdx-js/react": "^1.5.5",
+        "@pxblue/eslint-config": "^1.1.3",
+        "@pxblue/prettier-config": "^1.0.2",
+        "@svgr/webpack": "4.3.3",
+        "@testing-library/jest-dom": "^4.2.4",
+        "@testing-library/react": "^9.3.2",
+        "@testing-library/user-event": "^7.1.2",
+        "@types/axios": "^0.14.0",
+        "@types/brainhubeu__react-carousel": "^1.10.2",
+        "@types/enzyme": "^3.10.5",
+        "@types/enzyme-adapter-react-16": "^1.0.6",
+        "@types/jest": "^24.0.0",
+        "@types/mdx-js__react": "^1.5.0",
+        "@types/node": "^12.0.0",
+        "@types/react": "^16.9.0",
+        "@types/react-dom": "^16.9.0",
+        "@types/react-redux": "^7.1.7",
+        "@types/react-router-dom": "^5.1.3",
+        "@typescript-eslint/eslint-plugin": "^2.18.0",
+        "@typescript-eslint/parser": "^2.18.0",
+        "babel-eslint": "10.0.3",
+        "babel-jest": "^24.9.0",
+        "babel-loader": "8.0.6",
+        "babel-plugin-named-asset-import": "^0.3.5",
+        "babel-preset-react-app": "^9.1.0",
+        "camelcase": "^5.3.1",
+        "case-sensitive-paths-webpack-plugin": "2.2.0",
+        "css-loader": "3.2.0",
+        "dotenv": "8.2.0",
+        "dotenv-expand": "5.1.0",
+        "enzyme": "^3.11.0",
+        "enzyme-adapter-react-16": "^1.15.2",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-config-react-app": "^5.1.0",
+        "eslint-loader": "3.0.2",
+        "eslint-plugin-flowtype": "3.13.0",
+        "eslint-plugin-import": "2.18.2",
+        "eslint-plugin-jsx-a11y": "6.2.3",
+        "eslint-plugin-mdx": "^1.6.8",
+        "eslint-plugin-react": "^7.18.0",
+        "eslint-plugin-react-hooks": "^1.6.1",
+        "file-loader": "4.3.0",
+        "fs-extra": "^8.1.0",
+        "html-webpack-plugin": "4.0.0-beta.5",
+        "identity-obj-proxy": "3.0.0",
+        "jest": "24.9.0",
+        "jest-environment-jsdom-fourteen": "0.1.0",
+        "jest-resolve": "24.9.0",
+        "jest-transformer-mdx": "^2.1.0",
+        "jest-watch-typeahead": "0.4.2",
+        "markdown-link-check": "^3.8.0",
+        "mini-css-extract-plugin": "0.8.0",
+        "optimize-css-assets-webpack-plugin": "5.0.3",
+        "pnp-webpack-plugin": "1.5.0",
+        "postcss-flexbugs-fixes": "4.1.0",
+        "postcss-loader": "3.0.0",
+        "postcss-normalize": "8.0.1",
+        "postcss-preset-env": "6.7.0",
+        "postcss-safe-parser": "4.0.1",
+        "prettier": "^1.19.1",
+        "resolve": "1.12.2",
+        "resolve-url-loader": "3.1.1",
+        "sass-loader": "8.0.0",
+        "semver": "6.3.0",
+        "style-loader": "1.0.0",
+        "terser-webpack-plugin": "2.2.1",
+        "ts-pnp": "1.1.5",
+        "typeface-open-sans": "0.0.75",
+        "typeface-roboto-mono": "^0.0.75",
+        "typescript": "~3.7.2",
+        "url-loader": "2.3.0",
+        "webpack": "4.41.2",
+        "webpack-dev-server": "3.9.0",
+        "webpack-manifest-plugin": "2.2.0",
+        "workbox-webpack-plugin": "4.3.1"
+    },
+    "eslintConfig": {
+        "extends": "react-app"
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all",
+            "ie 11"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version",
+            "ie 11"
+        ]
+    },
+    "jest": {
+        "roots": [
+            "<rootDir>/src"
+        ],
+        "collectCoverageFrom": [
+            "src/**/*.{js,jsx,ts,tsx}",
+            "!src/**/*.d.ts"
+        ],
+        "setupFiles": [
+            "react-app-polyfill/jsdom"
+        ],
+        "setupFilesAfterEnv": [
+            "<rootDir>/src/setupTests.ts"
+        ],
+        "testMatch": [
+            "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
+            "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
+        ],
+        "testEnvironment": "jest-environment-jsdom-fourteen",
+        "transform": {
+            "^.+\\.(mdx)$": "jest-transformer-mdx",
+            "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
+            "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
+            "^(?!.*\\.(js|jsx|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
+        },
+        "transformIgnorePatterns": [
+            "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$",
+            "^.+\\.module\\.(css|sass|scss)$"
+        ],
+        "modulePaths": [],
+        "moduleNameMapper": {
+            "^react-native$": "react-native-web",
+            "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy"
+        },
+        "moduleFileExtensions": [
+            "web.js",
+            "js",
+            "web.ts",
+            "ts",
+            "web.tsx",
+            "tsx",
+            "json",
+            "web.jsx",
+            "jsx",
+            "node"
+        ],
+        "watchPlugins": [
+            "jest-watch-typeahead/filename",
+            "jest-watch-typeahead/testname"
+        ]
+    },
+    "babel": {
+        "presets": [
+            "react-app"
+        ]
+    }
 }

--- a/src/app/assets/icons/index.tsx
+++ b/src/app/assets/icons/index.tsx
@@ -1,5 +1,6 @@
 export { Dribbble } from './dribbble';
 export { GitHub } from './github';
 export { NPM } from './npm';
+export { MaterialDesign } from './materialDesign';
 export * from './eaton';
 export * from './frameworks';

--- a/src/app/assets/icons/materialDesign.tsx
+++ b/src/app/assets/icons/materialDesign.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
+
+export const MaterialDesign = (props: SvgIconProps): JSX.Element => (
+    <SvgIcon viewBox={'0 0 24 24'} {...props}>
+        <path
+            d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+            fill="#747474"
+        />
+        <path d="M19 5H5V19H19V5Z" fill="#C8C8C8" />
+        <path d="M5 5H19L12 19L5 5Z" fill="white" />
+    </SvgIcon>
+);

--- a/src/app/components/colors/Colors.tsx
+++ b/src/app/components/colors/Colors.tsx
@@ -4,7 +4,7 @@ import { Bookmark } from '@material-ui/icons';
 import * as Colors from '@pxblue/colors';
 import { AppState } from '../../redux/reducers';
 import { useSelector } from 'react-redux';
-import {PXBlueColor} from "@pxblue/types";
+import { PXBlueColor } from '@pxblue/types';
 
 const getColorLabel = (color: string): JSX.Element | null => {
     const format = useSelector((state: AppState) => state.app.colorFormat);

--- a/src/app/components/icons/ProgressIconCard.tsx
+++ b/src/app/components/icons/ProgressIconCard.tsx
@@ -6,7 +6,7 @@ import * as PXBColors from '@pxblue/colors';
 
 // Material-UI Components
 import { Typography, AppBar, Paper, Toolbar, makeStyles } from '@material-ui/core';
-import {PXBlueColor} from "@pxblue/types";
+import { PXBlueColor } from '@pxblue/types';
 
 const size = 48;
 type ColorPalette = {

--- a/src/app/components/navigation/SharedToolbar.tsx
+++ b/src/app/components/navigation/SharedToolbar.tsx
@@ -37,7 +37,6 @@ export const SharedToolbar = (props: SharedToolbarProps): JSX.Element => {
 
     const _navigationIcon = useCallback(
         () => (
-
             <Hidden mdUp={navigationIcon !== undefined && !isLandingPage}>
                 <IconButton
                     color={'inherit'}

--- a/src/app/components/patterns/MaterialDesignDescription.tsx
+++ b/src/app/components/patterns/MaterialDesignDescription.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { MaterialDesign } from '../../assets/icons';
+import { OpenInNew } from '@material-ui/icons';
+import {
+    Card,
+    Typography,
+    CardProps,
+    CardActionArea,
+    makeStyles,
+    createStyles,
+    Theme,
+    useTheme,
+    CardActionAreaProps,
+} from '@material-ui/core';
+
+type MaterialDesignDescriptionProps = {
+    // The icon used on the left
+    avatar?: JSX.Element;
+
+    // Secondary description text
+    description?: string;
+
+    // props applied to the card action area
+    CardActionAreaProps?: CardActionAreaProps;
+
+    // The icon used on the right
+    icon?: JSX.Element;
+
+    // Title text
+    title?: string;
+
+    // URL to be opened from a new window
+    url: string;
+} & CardProps;
+
+const useStyles = makeStyles((theme: Theme) =>
+    createStyles({
+        root: {
+            width: theme.spacing(38),
+            marginBottom: theme.spacing(2),
+            marginRight: theme.spacing(2),
+            display: 'inline-block',
+        },
+        actionArea: {
+            flexDirection: 'row',
+            display: 'flex',
+            padding: theme.spacing(1),
+            paddingBottom: theme.spacing(2),
+            alignItems: 'flex-start',
+        },
+        textArea: {
+            flex: 1,
+            margin: `0 ${theme.spacing(2)}px`,
+            minHeight: theme.spacing(12),
+        },
+    })
+);
+
+export const MaterialDesignDescription: React.FC<MaterialDesignDescriptionProps> = (props): JSX.Element => {
+    const theme = useTheme();
+    const classes = useStyles();
+    const {
+        avatar = <MaterialDesign style={{ height: theme.spacing(6), width: theme.spacing(6) }} />,
+        description = 'Read about how the pattern is defined in Material.io. Follow their instructions unless PX Blue has defined it otherwise.',
+        icon = <OpenInNew style={{ color: theme.palette.text.hint }} />,
+        title = "Material's Description",
+        url,
+        ...cardProps
+    } = props;
+    return (
+        <Card className={classes.root} {...cardProps}>
+            <CardActionArea
+                className={classes.actionArea}
+                onClick={(e): void => {
+                    if (e) {
+                        window.open(url);
+                    }
+                }}
+                {...props.CardActionAreaProps}
+            >
+                {avatar}
+                <div className={classes.textArea}>
+                    <Typography variant={'body2'} style={{ fontWeight: 600 }}>
+                        {title}
+                    </Typography>
+                    <Typography variant={'caption'}>{description}</Typography>
+                </div>
+                {icon}
+            </CardActionArea>
+        </Card>
+    );
+};

--- a/src/app/components/patterns/MaterialDesignDescription.tsx
+++ b/src/app/components/patterns/MaterialDesignDescription.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles((theme: Theme) =>
         textArea: {
             flex: 1,
             margin: `0 ${theme.spacing(2)}px`,
-            minHeight: theme.spacing(12),
+            minHeight: theme.spacing(15),
         },
     })
 );
@@ -61,9 +61,9 @@ export const MaterialDesignDescription: React.FC<MaterialDesignDescriptionProps>
     const classes = useStyles();
     const {
         avatar = <MaterialDesign style={{ height: theme.spacing(6), width: theme.spacing(6) }} />,
-        description = 'Read about how the pattern is defined in Material.io. Follow their instructions unless PX Blue has defined it otherwise.',
+        description = `Learn about Material Design's description of this pattern. Follow their guidance unless PX Blue recommends specific changes.`,
         icon = <OpenInNew style={{ color: theme.palette.text.hint }} />,
-        title = "Material's Description",
+        title = `Material's Description`,
         url,
         ...cardProps
     } = props;
@@ -73,7 +73,7 @@ export const MaterialDesignDescription: React.FC<MaterialDesignDescriptionProps>
                 className={classes.actionArea}
                 onClick={(e): void => {
                     if (e) {
-                        window.open(url);
+                        window.open(url, '_blank');
                     }
                 }}
                 {...props.CardActionAreaProps}

--- a/src/app/components/patterns/index.tsx
+++ b/src/app/components/patterns/index.tsx
@@ -1,3 +1,4 @@
 export * from './PatternGrid';
 export * from './DemoCard';
 export * from './ImageGrid';
+export * from './MaterialDesignDescription';

--- a/src/app/pages/Roadmap.tsx
+++ b/src/app/pages/Roadmap.tsx
@@ -24,7 +24,7 @@ import { InfoListItem, ListItemTag } from '@pxblue/react-components';
 
 import * as Colors from '@pxblue/colors';
 import { useBackgroundColor } from '../hooks/useBackgroundColor';
-import {PXBlueColor} from "@pxblue/types";
+import { PXBlueColor } from '@pxblue/types';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({

--- a/src/app/router/navigationDrawer.tsx
+++ b/src/app/router/navigationDrawer.tsx
@@ -44,9 +44,9 @@ export const NavigationDrawer = (): JSX.Element => {
                 itemID: fullURL,
                 onClick: item.component
                     ? (): void => {
-                          history.push(fullURL);
-                          dispatch({ type: TOGGLE_DRAWER, payload: false });
-                      }
+                        history.push(fullURL);
+                        dispatch({ type: TOGGLE_DRAWER, payload: false });
+                    }
                     : undefined,
                 items: item.pages ? createNavItems(item.pages, `${parentUrl}${item.url}`, depth + 1) : undefined,
             });
@@ -72,6 +72,7 @@ export const NavigationDrawer = (): JSX.Element => {
             style={{ boxShadow: theme.shadows[12] }}
             className={!isMobile && !isLandingPage ? classes.shadow : undefined}
             variant={isMobile || isLandingPage ? 'temporary' : 'permanent'}
+            activeItemBackgroundColor={theme.palette.primary.light}
         >
             <DrawerHeader
                 backgroundColor={Colors.blue[500]}

--- a/src/docs/patterns/appbar.mdx
+++ b/src/docs/patterns/appbar.mdx
@@ -8,7 +8,7 @@ import Image4 from '../../app/assets/design-patterns/search-bar/search-bar-searc
 
 App bars are useful in a variety of locations throughout PX Blue applications. They are typically used to provide a title or description for a collection of data that follows. They may also contain a menu and/or various actions that can be performed.
 
-<MaterialDesignDescription title={'App bars: top'} url={'https://material.io/components/app-bars-top/'} />
+<MaterialDesignDescription title={'App Bars: Top'} url={'https://material.io/components/app-bars-top/'} />
 
 ## A Basic App Bar
 

--- a/src/docs/patterns/appbar.mdx
+++ b/src/docs/patterns/appbar.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import Image1 from '../../app/assets/design-patterns/collapsible-appbar/collapsible-appbar-expanded.png';
 import Image2 from '../../app/assets/design-patterns/collapsible-appbar/collapsible-appbar-collapsed.png';
 import Image3 from '../../app/assets/design-patterns/search-bar/search-bar.png';
@@ -7,6 +7,8 @@ import Image4 from '../../app/assets/design-patterns/search-bar/search-bar-searc
 # App Bar Patterns
 
 App bars are useful in a variety of locations throughout PX Blue applications. They are typically used to provide a title or description for a collection of data that follows. They may also contain a menu and/or various actions that can be performed.
+
+<MaterialDesignDescription title={'App bars: top'} url={'https://material.io/components/app-bars-top/'} />
 
 ## A Basic App Bar
 

--- a/src/docs/patterns/empty-states.mdx
+++ b/src/docs/patterns/empty-states.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import Image1 from '../../app/assets/design-patterns/loading-states/loading-state-load.png';
 import Image2 from '../../app/assets/design-patterns/loading-states/loading-state.png';
 import Image3 from '../../app/assets/design-patterns/empty-states/empty-states.png';
@@ -41,7 +41,9 @@ If your users can manually refresh, you may wish to show the placeholder element
 
 Empty states can be used in a variety of ways in your application. They can alert users to empty data or search results, lack of permissions, future features, or errors.
 
-You can refer to the [Material Design Empty States](https://material.io/design/communication/empty-states.html) guidelines for general usage instructions.
+You can refer to the Material Design Empty States guidelines for general usage instructions.
+
+<MaterialDesignDescription title={'Text fields'} url={'https://material.io/design/communication/empty-states.html'} />
 
 Empty states should include a large icon or graphic, centered on the screen, followed a brief message. In some cases, you may wish to use a large graphic as the background of the entire page as well (such as for features that will be coming soon).
 

--- a/src/docs/patterns/empty-states.mdx
+++ b/src/docs/patterns/empty-states.mdx
@@ -43,7 +43,7 @@ Empty states can be used in a variety of ways in your application. They can aler
 
 You can refer to the Material Design Empty States guidelines for general usage instructions.
 
-<MaterialDesignDescription title={'Text fields'} url={'https://material.io/design/communication/empty-states.html'} />
+<MaterialDesignDescription title={'Empty States'} url={'https://material.io/design/communication/empty-states.html'} />
 
 Empty states should include a large icon or graphic, centered on the screen, followed a brief message. In some cases, you may wish to use a large graphic as the background of the entire page as well (such as for features that will be coming soon).
 

--- a/src/docs/patterns/forms.mdx
+++ b/src/docs/patterns/forms.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import Image1 from '../../app/assets/design-patterns/form-validation/form-validation-interaction.png';
 import Image2 from '../../app/assets/design-patterns/form-validation/form-validation-feedback.png';
 import Image3 from '../../app/assets/design-patterns/form-validation/form-validation-variation.png';
@@ -11,7 +11,9 @@ import Image6 from '../../app/assets/design-patterns/form-validation/form-valida
 <ImageGrid images={[Image1, Image2, Image3]} />
 <DemoCard repository={'form-validation'} angular react float={'right'} />
 
-Forms are an integral part of many applications, particularly during the user registration phase. One of the most important parts of working with forms is properly validating the information that users enter into them. In general, PX Blue follows the form behaviors explained in detail by [Google Material](https://material.io/design/components/text-fields.html#anatomy).
+Forms are an integral part of many applications, particularly during the user registration phase. One of the most important parts of working with forms is properly validating the information that users enter into them. In general, PX Blue follows the form behaviors explained in detail by the Material Design.
+
+<MaterialDesignDescription title={'Text fields'} url={'https://material.io/components/text-fields/'} />
 
 ## Optional vs. Required Fields
 

--- a/src/docs/patterns/forms.mdx
+++ b/src/docs/patterns/forms.mdx
@@ -13,7 +13,7 @@ import Image6 from '../../app/assets/design-patterns/form-validation/form-valida
 
 Forms are an integral part of many applications, particularly during the user registration phase. One of the most important parts of working with forms is properly validating the information that users enter into them. In general, PX Blue follows the form behaviors explained in detail by the Material Design.
 
-<MaterialDesignDescription title={'Text fields'} url={'https://material.io/components/text-fields/'} />
+<MaterialDesignDescription title={'Text Fields'} url={'https://material.io/components/text-fields/'} />
 
 ## Optional vs. Required Fields
 

--- a/src/docs/patterns/internationalization.mdx
+++ b/src/docs/patterns/internationalization.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import Image1 from '../../app/assets/design-patterns/internationalization/web-internationalization-english.png';
 import Image2 from '../../app/assets/design-patterns/internationalization/web-internationalization-arabic.png';
 import Image3 from '../../app/assets/design-patterns/internationalization/web-internationalization-spanish.png';
@@ -12,6 +12,11 @@ Internationalization is the practice of adapting applications to various regions
 
 ## Language Support
 
+<MaterialDesignDescription
+    title={'Language support'}
+    url={'https://material.io/design/typography/language-support.html#language-considerations'}
+/>
+
 To localize your application content, you should create a string resource file or object that contains the translations for any display text used in your application. You will not want to have any text hard-coded in your application's UI. To switch your application to another language, you simply toggle the file/object used to populate the UI to the appropriate translation.
 
 Different languages/writing systems may require different vertical and horizontal space. To ensure flexibility, avoid using fixed dimensions for necessary UI components such as buttons, labels, and badges. Also, consider setting different default display font sizes for languages that may have smaller glyphs.
@@ -24,6 +29,12 @@ When showing a list of languages, you can decide whether you want to translate t
 
 ## Bi-directionality/ Right-to-Left (RTL) Support
 
+<MaterialDesignDescription
+    title={'Bidirectionality'}
+    description={'Learn about mirroring layout, mirroring elements, and localization.'}
+    url={'https://material.io/design/usability/bidirectionality.html'}
+/>
+
 Some languages, such as Arabic and Hebrew, are read from right to left. Applications supporting these languages will need to mirror the UI so the natural flow is from right to left. For example, navigation drawers should be displayed on the right side of the screen, icons should be to the right of the text in buttons, and any icons with directionality should be mirrored.
 
 ## Technical Implementation
@@ -31,9 +42,10 @@ Some languages, such as Arabic and Hebrew, are read from right to left. Applicat
 There are a number of available libraries to assist with implementing internationalization in your applications.
 
 ### Angular
+
 Angular has built-in internationalization tools available; view Angular's [internationalization](https://angular.io/guide/i18n) documentation here.
 
 ### React or React Native
+
 There are many JS libraries available to help internationalize your application. If you are already using PX Blue, [Material UI](https://material-ui.com/guides/localization/) has a lightweight solution available.
 For heavier projects, we recommend using a third-party solution [react-i18next](https://github.com/i18next/react-i18next).
-

--- a/src/docs/patterns/internationalization.mdx
+++ b/src/docs/patterns/internationalization.mdx
@@ -12,12 +12,12 @@ Internationalization is the practice of adapting applications to various regions
 
 ## Language Support
 
+To localize your application content, you should create a string resource file or object that contains the translations for any display text used in your application. You will not want to have any text hard-coded in your application's UI. To switch your application to another language, you simply toggle the file/object used to populate the UI to the appropriate translation.
+
 <MaterialDesignDescription
-    title={'Language support'}
+    title={'Language Support'}
     url={'https://material.io/design/typography/language-support.html#language-considerations'}
 />
-
-To localize your application content, you should create a string resource file or object that contains the translations for any display text used in your application. You will not want to have any text hard-coded in your application's UI. To switch your application to another language, you simply toggle the file/object used to populate the UI to the appropriate translation.
 
 Different languages/writing systems may require different vertical and horizontal space. To ensure flexibility, avoid using fixed dimensions for necessary UI components such as buttons, labels, and badges. Also, consider setting different default display font sizes for languages that may have smaller glyphs.
 
@@ -29,13 +29,13 @@ When showing a list of languages, you can decide whether you want to translate t
 
 ## Bi-directionality/ Right-to-Left (RTL) Support
 
+Some languages, such as Arabic and Hebrew, are read from right to left. Applications supporting these languages will need to mirror the UI so the natural flow is from right to left. For example, navigation drawers should be displayed on the right side of the screen, icons should be to the right of the text in buttons, and any icons with directionality should be mirrored.
+
 <MaterialDesignDescription
     title={'Bidirectionality'}
     description={'Learn about mirroring layout, mirroring elements, and localization.'}
     url={'https://material.io/design/usability/bidirectionality.html'}
 />
-
-Some languages, such as Arabic and Hebrew, are read from right to left. Applications supporting these languages will need to mirror the UI so the natural flow is from right to left. For example, navigation drawers should be displayed on the right side of the screen, icons should be to the right of the text in buttons, and any icons with directionality should be mirrored.
 
 ## Technical Implementation
 

--- a/src/docs/patterns/layout.mdx
+++ b/src/docs/patterns/layout.mdx
@@ -1,4 +1,4 @@
-import { ImageGrid } from '../../app/components';
+import { ImageGrid, MaterialDesignDescription } from '../../app/components';
 import PageLayoutImage from '../../app/assets/design-patterns/page-layout/page-layout.png';
 
 # Page Layout Patterns
@@ -6,6 +6,8 @@ import PageLayoutImage from '../../app/assets/design-patterns/page-layout/page-l
 <ImageGrid images={[PageLayoutImage]} />
 
 The layout is one of the most fundamental aspects of your application - it's how you place and position all of the different elements on your page. It's also one of the most important aspects when building your application to be responsive and usable on a variety of different devices and screen sizes.
+
+<MaterialDesignDescription title={'Layout'} url={'https://material.io/design/layout/understanding-layout.html'} />
 
 > **NOTE:** PX Blue does not support the use of Twitter Bootstrap for PX Blue applications. Bootstrap can cause conflicts with PX Blue components and themes and is an unnecessary addition next to the Material component libraries and frameworks supported by PX Blue. If you are accustomed to using Bootstrap for layout, you can read about the PX Blue alternative approach below.
 

--- a/src/docs/patterns/lists.mdx
+++ b/src/docs/patterns/lists.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import Image1 from '../../app/assets/design-patterns/data-list/simple-list.png';
 import Image2 from '../../app/assets/design-patterns/status-list/status-list.png';
 import Image3 from '../../app/assets/design-patterns/action-list/action-list.png';
@@ -11,6 +11,8 @@ import Image8 from '../../app/assets/design-patterns/sortable-list/sortable-list
 # List Patterns
 
 Lists are frequently used throughout PX Blue applications. Typically, lists are used to represent groups of similar data. They can be used to show simple name-value pairs in a sidebar all the way to complex timelines or device lists.
+
+<MaterialDesignDescription title={'Lists'} url={'https://material.io/components/lists/'} />
 
 ## Basic Lists
 

--- a/src/docs/patterns/lists.mdx
+++ b/src/docs/patterns/lists.mdx
@@ -56,3 +56,5 @@ Occasionally, you may want users to be able to re-order the items in a list manu
 <DemoCard repository={'responsive-table'} angular react float={'right'} />
 
 Tables are similar to lists but are slightly more structured by ordering data for a list item into columns. These work well on larger screens, but at a mobile size, they should collapse into a list for better formatting.
+
+<MaterialDesignDescription title={'Data Tables'} url={'https://material.io/components/data-tables/'} />

--- a/src/docs/patterns/navigation.mdx
+++ b/src/docs/patterns/navigation.mdx
@@ -8,11 +8,11 @@ import PersistentImg from '../../app/assets/design-patterns/navigation/navigatio
 Navigation is the way in which users access the different areas of your application. This is typically accomplished through a side drawer navigation panel with a list of links to the various pages in your application.
 
 <MaterialDesignDescription
-    title={'Understanding navigation'}
+    title={'Understanding Navigation'}
     url={'https://material.io/design/navigation/understanding-navigation.html#types-of-navigation'}
 />
 <MaterialDesignDescription
-    title={'Navigation drawer '}
+    title={'Navigation Drawer '}
     url={'https://material.io/components/navigation-drawer/'}
     style={{marginRight: 0}}
 />

--- a/src/docs/patterns/navigation.mdx
+++ b/src/docs/patterns/navigation.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import PermanentImg from '../../app/assets/design-patterns/navigation/navigation-permanent.png';
 import TemporaryImg from '../../app/assets/design-patterns/navigation/navigation-temporary.png';
 import PersistentImg from '../../app/assets/design-patterns/navigation/navigation-persistent.png';
@@ -6,6 +6,16 @@ import PersistentImg from '../../app/assets/design-patterns/navigation/navigatio
 # Navigation Patterns
 
 Navigation is the way in which users access the different areas of your application. This is typically accomplished through a side drawer navigation panel with a list of links to the various pages in your application.
+
+<MaterialDesignDescription
+    title={'Understanding navigation'}
+    url={'https://material.io/design/navigation/understanding-navigation.html#types-of-navigation'}
+/>
+<MaterialDesignDescription
+    title={'Navigation drawer '}
+    url={'https://material.io/components/navigation-drawer/'}
+    style={{marginRight: 0}}
+/>
 
 ## Fixed Navigation
 

--- a/src/docs/patterns/overlay.mdx
+++ b/src/docs/patterns/overlay.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 import BasicBottomsheet from '../../app/assets/design-patterns/action-list/action-list-overlay.png';
 import ComplexBottomsheet from '../../app/assets/design-patterns/bottom-sheet/complex-bottomsheet.png';
 
@@ -10,9 +10,17 @@ Overlays are useful for times when you want to block interaction with the page t
 
 The modal dialog is your typical pop-up window. These are traditionally used when you need to confirm a user action (such as deleting an item). These usually appear in the center of the screen.
 
+<MaterialDesignDescription
+    title={'Dialogs'}
+    url={'https://material.io/components/dialogs/'}
+    description={'Read more about dialogs on Material.io.'}
+/>
+
 ## Bottom Sheet
 
 A bottom sheet is similar to a modal dialog, but slides in from the bottom of the screen. A dark overlay is usually used to block user interaction with the main app until the bottom sheet is closed.
+
+<MaterialDesignDescription title={'Sheets: bottom'} url={'https://material.io/components/sheets-bottom/'} />
 
 This is a very common pattern in mobile applications, but can also be used in responsive web apps. Typically, the bottom sheet contains global actions for the entire page and is activated by a button in the app bar.
 

--- a/src/docs/patterns/overlay.mdx
+++ b/src/docs/patterns/overlay.mdx
@@ -20,7 +20,7 @@ The modal dialog is your typical pop-up window. These are traditionally used whe
 
 A bottom sheet is similar to a modal dialog, but slides in from the bottom of the screen. A dark overlay is usually used to block user interaction with the main app until the bottom sheet is closed.
 
-<MaterialDesignDescription title={'Sheets: bottom'} url={'https://material.io/components/sheets-bottom/'} />
+<MaterialDesignDescription title={'Sheets: Bottom'} url={'https://material.io/components/sheets-bottom/'} />
 
 This is a very common pattern in mobile applications, but can also be used in responsive web apps. Typically, the bottom sheet contains global actions for the entire page and is activated by a button in the app bar.
 

--- a/src/docs/patterns/visualizations.mdx
+++ b/src/docs/patterns/visualizations.mdx
@@ -1,4 +1,4 @@
-import { DemoCard, ImageGrid } from '../../app/components';
+import { DemoCard, ImageGrid, MaterialDesignDescription } from '../../app/components';
 
 import DataVizImage from '../../app/assets/design-patterns/data-visualization/data-visualization.png';
 
@@ -7,6 +7,11 @@ import DataVizImage from '../../app/assets/design-patterns/data-visualization/da
 <ImageGrid images={[DataVizImage]} />
 
 There are many opportunities to visualize data in different applications. The most common visualizations used in PX Blue applications come in the form of charts/graphs and maps.
+
+<MaterialDesignDescription
+    title={'Data Visualization'}
+    url={'https://material.io/design/communication/data-visualization.html'}
+/>
 
 ## Charts & Graphs (Highcharts & ChartJS)
 

--- a/src/docs/style/color.mdx
+++ b/src/docs/style/color.mdx
@@ -1,4 +1,4 @@
-import { ColorPalette, HeadlineWithToggle } from '../../app/components';
+import { ColorPalette, HeadlineWithToggle, MaterialDesignDescription } from '../../app/components';
 import * as Colors from '@pxblue/colors';
 import * as BrandingColors from '@pxblue/colors-branding';
 import { Typography } from '@material-ui/core';
@@ -6,7 +6,9 @@ import { Bookmark } from '@material-ui/icons';
 
 <HeadlineWithToggle />
 
-PX Blue offers a variety of different colors for use in your applications. Our color palettes utilize a weighted approach to give designers and developers a versatile set of colors for solving common color-related issues (e.g., accessibility). [Learn more about weighted color palettes](https://material.io/design/color/).
+PX Blue offers a variety of different colors for use in your applications. Our color palettes utilize a weighted approach to give designers and developers a versatile set of colors for solving common color-related issues (e.g., accessibility).
+
+<MaterialDesignDescription title={'The color system'} url={'https://material.io/design/color/'} />
 
 Our color sets are divided into sections as outlined below. User Interface and Status colors are available in a single package ([@pxblue/colors](https://www.npmjs.com/package/@pxblue/colors)). Branding (Charts and Graphs) colors are available as an additional package ([@pxblue/colors-branding](https://www.npmjs.com/package/@pxblue/colors-branding)).
 

--- a/src/docs/style/color.mdx
+++ b/src/docs/style/color.mdx
@@ -8,7 +8,11 @@ import { Bookmark } from '@material-ui/icons';
 
 PX Blue offers a variety of different colors for use in your applications. Our color palettes utilize a weighted approach to give designers and developers a versatile set of colors for solving common color-related issues (e.g., accessibility).
 
-<MaterialDesignDescription title={'The color system'} url={'https://material.io/design/color/'} />
+<MaterialDesignDescription
+    title={'The Color System'}
+    url={'https://material.io/design/color/'}
+    description={`Material's color principles. You should adhere to PX Blue's color theme unless you are creating your own components.`}
+/>
 
 Our color sets are divided into sections as outlined below. User Interface and Status colors are available in a single package ([@pxblue/colors](https://www.npmjs.com/package/@pxblue/colors)). Branding (Charts and Graphs) colors are available as an additional package ([@pxblue/colors-branding](https://www.npmjs.com/package/@pxblue/colors-branding)).
 

--- a/src/docs/style/iconography.mdx
+++ b/src/docs/style/iconography.mdx
@@ -13,7 +13,7 @@ These icons are available in a variety of formats - select an icon below to view
     <MaterialDesignDescription
         title={'System icons'}
         url={'https://material.io/design/iconography/system-icons.html#'}
-        description={`Material Design's guideline on creating your own icons.`}
+        description={`Material Design's guidelines on creating your own icons.`}
     />
     <MaterialDesignDescription
         title={`Material's icon`}

--- a/src/docs/style/iconography.mdx
+++ b/src/docs/style/iconography.mdx
@@ -9,8 +9,20 @@ specific to PX Blue products.
 
 These icons are available in a variety of formats - select an icon below to view its usage instructions.
 
-<span /><MaterialDesignDescription title={'System icons'} url={'https://material.io/design/iconography/system-icons.html#'} /><MaterialDesignDescription title={'Material\'s icon'} url={'https://material.io/resources/icons/'} description={'List of Material Design icons. They are also included in the table below.'} style={{marginRight:0}}/>
-<IconBrowser />
+<React.Fragment>
+    <MaterialDesignDescription
+        title={'System icons'}
+        url={'https://material.io/design/iconography/system-icons.html#'}
+        description={`Material Design's guideline on creating your own icons.`}
+    />
+    <MaterialDesignDescription
+        title={`Material's icon`}
+        url={'https://material.io/resources/icons/'}
+        description={'List of Material Design icons. They are also included in the table below.'}
+        style={{ marginRight: 0 }}
+    />
+    <IconBrowser />
+</React.Fragment>
 
 ## Progress icons
 

--- a/src/docs/style/iconography.mdx
+++ b/src/docs/style/iconography.mdx
@@ -1,4 +1,4 @@
-import { IconBrowser, ProgressIconCard } from '../../app/components';
+import { IconBrowser, ProgressIconCard, MaterialDesignDescription } from '../../app/components';
 
 # Iconography guidelines
 
@@ -9,6 +9,7 @@ specific to PX Blue products.
 
 These icons are available in a variety of formats - select an icon below to view its usage instructions.
 
+<span /><MaterialDesignDescription title={'System icons'} url={'https://material.io/design/iconography/system-icons.html#'} /><MaterialDesignDescription title={'Material\'s icon'} url={'https://material.io/resources/icons/'} description={'List of Material Design icons. They are also included in the table below.'} style={{marginRight:0}}/>
 <IconBrowser />
 
 ## Progress icons
@@ -31,7 +32,7 @@ existing icon is available for you to use.
 If you are looking for the PX Blue 1.0 symbols, please refer to our [Github](https://github.com/pxblue/icons/tree/master/symbols).
 
 If you have your own design resources who are able to create icons, you can build these on your own,
-following the [Material Icon Guidelines](https://material.io/guidelines/style/icons.html#icons-product-icons)
+following the [Material Icon Guidelines](https://material.io/design/iconography/system-icons.html)
 to maintain a common look and feel. If you do not have your own designers, we can work with you to build
 the icon you need. We can either build the icon in house or recommend external resources that you can
 use. Please note that going this route may take extra time, so try to get requests in as early as

--- a/src/docs/style/themes.mdx
+++ b/src/docs/style/themes.mdx
@@ -1,10 +1,22 @@
-import { ImageGrid, DemoCard } from '../../app/components';
+import { ImageGrid, DemoCard, MaterialDesignDescription } from '../../app/components';
 import LightThemeImage from '../../app/assets/design-patterns/theme/theme-light.png';
 import DarkThemeImage from '../../app/assets/design-patterns/theme/theme-dark.png';
 
 # Power Xpert Blue Themes
 
 One of the key benefits of PX Blue is consistency of look & feel between different applications. This is achieved primarily through the use of PX Blue themes.
+
+<MaterialDesignDescription
+    title={'Material Theming Overview'}
+    description={'Material Design\'s brief introduction to theming.'}
+    url={'https://material.io/design/material-theming/overview.html#'}
+/>
+<MaterialDesignDescription
+    title={'Dark theme'}
+    url={'https://material.io/design/color/dark-theme.html'}
+    description={'Material Design\'s dark theme guide.'}
+    style={{marginRight: 0}}
+/>
 
 ## Available Themes
 

--- a/src/docs/style/themes.mdx
+++ b/src/docs/style/themes.mdx
@@ -8,13 +8,13 @@ One of the key benefits of PX Blue is consistency of look & feel between differe
 
 <MaterialDesignDescription
     title={'Material Theming Overview'}
-    description={'Material Design\'s brief introduction to theming.'}
+    description={`Material Design's brief introduction to theming.`}
     url={'https://material.io/design/material-theming/overview.html#'}
 />
 <MaterialDesignDescription
-    title={'Dark theme'}
+    title={'Dark Theme'}
     url={'https://material.io/design/color/dark-theme.html'}
-    description={'Material Design\'s dark theme guide.'}
+    description={`Material Design's dark theme guide.`}
     style={{marginRight: 0}}
 />
 

--- a/src/docs/style/typography.mdx
+++ b/src/docs/style/typography.mdx
@@ -11,7 +11,7 @@ PX Blue builds off of the Material Design system, so in general, you may refer t
 <MaterialDesignDescription
     title={'The Type System'}
     url={'https://material.io/guidelines/style/typography.html'}
-    description={`Material Design's typography guideline.`}
+    description={`Material Design's typography guidelines.`}
 />
 
 Unlike Material Design, the primary font for Power Xpert Blue is [Open Sans](https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans) (licensed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)). This version contains the complete 897 character set, which includes the standard ISO Latin 1, Latin CE, Greek and Cyrillic character sets. Open Sans was optimized for print, web, and mobile interfaces, and has excellent legibility characteristics in its letter forms.

--- a/src/docs/style/typography.mdx
+++ b/src/docs/style/typography.mdx
@@ -8,7 +8,11 @@ import HeadlineOptionsImg from '../../app/assets/typography/headline-options.png
 
 PX Blue builds off of the Material Design system, so in general, you may refer to the typography guidelines presented at [Material.io](https://material.io/guidelines/style/typography.html#). Below, we cover some of the areas where PX Blue differs from Material Design.
 
-<MaterialDesignDescription title={'The type system'} url={'https://material.io/guidelines/style/typography.html'} />
+<MaterialDesignDescription
+    title={'The Type System'}
+    url={'https://material.io/guidelines/style/typography.html'}
+    description={`Material Design's typography guideline.`}
+/>
 
 Unlike Material Design, the primary font for Power Xpert Blue is [Open Sans](https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans) (licensed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)). This version contains the complete 897 character set, which includes the standard ISO Latin 1, Latin CE, Greek and Cyrillic character sets. Open Sans was optimized for print, web, and mobile interfaces, and has excellent legibility characteristics in its letter forms.
 

--- a/src/docs/style/typography.mdx
+++ b/src/docs/style/typography.mdx
@@ -1,4 +1,4 @@
-import { ImageGrid } from '../../app/components/patterns/ImageGrid';
+import { ImageGrid, MaterialDesignDescription } from '../../app/components';
 import TypeScaleImg from '../../app/assets/typography/type-scale.png';
 import LargerApplicationImg from '../../app/assets/typography/larger-application.png';
 import ApplicationImg from '../../app/assets/typography/application.png';
@@ -7,6 +7,8 @@ import HeadlineOptionsImg from '../../app/assets/typography/headline-options.png
 # Typography Guidelines
 
 PX Blue builds off of the Material Design system, so in general, you may refer to the typography guidelines presented at [Material.io](https://material.io/guidelines/style/typography.html#). Below, we cover some of the areas where PX Blue differs from Material Design.
+
+<MaterialDesignDescription title={'The type system'} url={'https://material.io/guidelines/style/typography.html'} />
 
 Unlike Material Design, the primary font for Power Xpert Blue is [Open Sans](https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans) (licensed under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)). This version contains the complete 897 character set, which includes the standard ISO Latin 1, Latin CE, Greek and Cyrillic character sets. Open Sans was optimized for print, web, and mobile interfaces, and has excellent legibility characteristics in its letter forms.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,12 +1852,12 @@
   resolved "https://registry.yarnpkg.com/@pxblue/react-progress-icons/-/react-progress-icons-2.0.0.tgz#b1e1aa21ae871b60a3cdadd926569737e581a7e2"
   integrity sha512-S1upGm3FReTL/mwzjxAAvHubtCfgwbqKzJbOA47pRkE9tKpebi/eMoitA1RwATTYdwxjcvVF7373UZctcLa0+A==
 
-"@pxblue/react-themes@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@pxblue/react-themes/-/react-themes-4.0.0.tgz#5b3b2f87b9558439a59a0fadd06cc9bcb375c477"
-  integrity sha512-w0VFVZ+BLPk0AVNL0vWK7z8cl8Ec2seHOu68Dwl2R+CZ7iVuz6f+1I/KXjzjL458YWjNK1lu9UiaCX34MxvpHQ==
+"@pxblue/react-themes@^5.0.0-beta.0":
+  version "5.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/react-themes/-/react-themes-5.0.0-beta.0.tgz#a5fcbd507a92ce7f4d41542bdf8356fc1f6168a1"
+  integrity sha512-Iv3RnsWEP0/8sDlO1nCovwWg2WR4TTTZxIxsko7s649jkLIf6KFjA+vTX/G16u5SjoqSlmy4qEyjMPerUSFzoQ==
   dependencies:
-    "@pxblue/colors" "^2.0.0"
+    "@pxblue/colors" "^2.0.1"
     typeface-open-sans "^0.0.75"
 
 "@pxblue/types@^1.0.0":


### PR DESCRIPTION
Changes proposed in this Pull Request:
- Added component `MaterialDesignDescription`
- Add the corresponding material io link to the design pattern pages and style guide pages
- Prettier. 

## Screenshots

### Color Palette
![image](https://user-images.githubusercontent.com/8997218/78846192-f8a9dd00-79d8-11ea-8732-3d8fc7bc9728.png)

### App Bar

![image](https://user-images.githubusercontent.com/8997218/78846203-ff385480-79d8-11ea-8d5d-4565ac252035.png)

