### PR TITLE
Ability to deep link to icons

### DIFF
--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -24,6 +24,7 @@ import { IconCard } from './IconCard';
 import { IconMenu } from './IconMenu';
 import { unCamelCase } from '../../shared/utilities';
 import { Icon, MatIconList, DetailedIcon } from '../../../__types__';
+import { useQueryString } from '../../hooks/useQueryString';
 
 type LetterGroups = {
     [key: string]: boolean;
@@ -179,7 +180,12 @@ const iconMatches = (icon: Icon, search: string, filterMaterial: boolean): boole
         .toLowerCase()
         .split(/\s+/);
     for (let i = 0; i < searchArray.length; i++) {
-        if (!icon.name.toLowerCase().includes(searchArray[i])) {
+        if (
+            !icon.name
+                .toLowerCase()
+                .replace(/[ _]/g, '')
+                .includes(searchArray[i])
+        ) {
             return false;
         }
     }
@@ -188,11 +194,20 @@ const iconMatches = (icon: Icon, search: string, filterMaterial: boolean): boole
 };
 
 export const IconBrowser: React.FC = (): JSX.Element => {
-    const [search, setSearch] = useState<string>('');
-    const [hideLetterGroups, setHideLetterGroups] = useState<LetterGroups>({});
-    const [focusedIcon, setFocusedIcon] = useState<Icon>({ name: '', isMaterial: true });
-    const [filterMaterial, setFilterMaterial] = useState(false);
     const classes = useStyles();
+    const query = useQueryString();
+
+    const [search, setSearch] = useState<string>(() => query.search || query.icon || '');
+    const [hideLetterGroups, setHideLetterGroups] = useState<LetterGroups>({});
+    const [focusedIcon, setFocusedIcon] = useState<Icon>(() => {
+        const blankIcon = { name: '', isMaterial: true };
+        const icon = query.icon;
+        if (!icon) return blankIcon;
+        if (Icons[icon]) return { name: icon, isMaterial: false };
+        if (MaterialIcons[getMuiIconName(icon)]) return { name: getMuiIconName(icon), isMaterial: true };
+        return blankIcon;
+    });
+    const [filterMaterial, setFilterMaterial] = useState(false);
 
     const icons: Icon[] = createIconList();
     const iconList: Icon[] = icons;

--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -317,7 +317,9 @@ export const IconBrowser: React.FC = (): JSX.Element => {
                                                     <div
                                                         key={`${icon.name} + ${icon.isMaterial.toString()}`}
                                                         onClick={(): void => {
-                                                            history.replace(`${location.pathname}?icon=${icon.name}`);
+                                                            history.replace(
+                                                                `${location.pathname}?icon=${getMuiIconName(icon.name)}`
+                                                            );
                                                             setFocusedIcon(icon);
                                                         }}
                                                     >
@@ -330,7 +332,11 @@ export const IconBrowser: React.FC = (): JSX.Element => {
                                                             }
                                                             name={unCamelCase(getMuiIconName(icon.name))}
                                                             className={classes.iconCard}
-                                                            selected={focusedIcon && focusedIcon.name === icon.name}
+                                                            selected={
+                                                                focusedIcon &&
+                                                                getMuiIconName(focusedIcon.name) ===
+                                                                    getMuiIconName(icon.name)
+                                                            }
                                                         />
                                                     </div>
                                                 ))}

--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -25,6 +25,7 @@ import { IconMenu } from './IconMenu';
 import { unCamelCase } from '../../shared/utilities';
 import { Icon, MatIconList, DetailedIcon } from '../../../__types__';
 import { useQueryString } from '../../hooks/useQueryString';
+import { useHistory, useLocation } from 'react-router-dom';
 
 type LetterGroups = {
     [key: string]: boolean;
@@ -195,10 +196,17 @@ const iconMatches = (icon: Icon, search: string, filterMaterial: boolean): boole
 
 export const IconBrowser: React.FC = (): JSX.Element => {
     const classes = useStyles();
+    const history = useHistory();
+    const location = useLocation();
     const query = useQueryString();
 
-    const [search, setSearch] = useState<string>(() => query.search || query.icon || '');
-    const [hideLetterGroups, setHideLetterGroups] = useState<LetterGroups>({});
+    const [search, setSearch] = useState<string>(() => query.search || '');
+    const [hideLetterGroups, setHideLetterGroups] = useState<LetterGroups>(() => {
+        if (query.icon) {
+            return { [query.icon.charAt(0).toUpperCase()]: true };
+        }
+        return {};
+    });
     const [focusedIcon, setFocusedIcon] = useState<Icon>(() => {
         const blankIcon = { name: '', isMaterial: true };
         const icon = query.icon;
@@ -309,7 +317,7 @@ export const IconBrowser: React.FC = (): JSX.Element => {
                                                     <div
                                                         key={`${icon.name} + ${icon.isMaterial.toString()}`}
                                                         onClick={(): void => {
-                                                            setFocusedIcon({ name: '', isMaterial: true });
+                                                            history.replace(`${location.pathname}?icon=${icon.name}`);
                                                             setFocusedIcon(icon);
                                                         }}
                                                     >

--- a/src/app/components/icons/IconCard.tsx
+++ b/src/app/components/icons/IconCard.tsx
@@ -18,7 +18,6 @@ const useStyles = makeStyles(() => ({
         background: PXBColors.blue[50],
     },
     label: {
-        cursor: 'default',
         width: '100%',
         textAlign: 'center',
         wordBreak: 'break-word',

--- a/src/app/components/icons/IconMenu.tsx
+++ b/src/app/components/icons/IconMenu.tsx
@@ -36,6 +36,8 @@ const useStyles = makeStyles((theme: Theme) =>
         iconSheet: {
             color: PXBColors.black[900],
             width: '100%',
+            maxHeight: `calc(100% - 64px)`,
+            overflowY: 'auto',
             left: 0,
             right: 0,
             bottom: 0,
@@ -44,8 +46,9 @@ const useStyles = makeStyles((theme: Theme) =>
             marginLeft: 'auto',
             marginRight: 'auto',
             outline: 'none',
+            boxShadow: theme.shadows[4],
             [theme.breakpoints.up('md')]: {
-                left: '364px',
+                left: 270,
                 width: '600px',
             },
             [theme.breakpoints.down('xs')]: {

--- a/src/app/components/icons/IconMenu.tsx
+++ b/src/app/components/icons/IconMenu.tsx
@@ -21,17 +21,17 @@ import {
 } from '@material-ui/core';
 import meta from '@pxblue/icons-mui/index.json';
 import { ExternalLink } from '../../../__configuration__/markdown/markdownMapping';
-import { unCamelCase, getSnakeCase } from '../../shared/utilities';
+import { unCamelCase, getSnakeCase, getKebabCase } from '../../shared/utilities';
 import { IconCard } from './IconCard';
 import { Icon, MatIconList, DetailedIcon } from '../../../__types__';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         usageBox: {
-            padding: `10px ${theme.spacing(2)}px 0px ${theme.spacing(2)}px`,
+            padding: `10px ${theme.spacing(2)}px ${theme.spacing(4)}px ${theme.spacing(2)}px`,
             overflowX: 'auto',
-            height: '230px',
-            overflowY: 'hidden',
+            height: '250px',
+            overflowY: 'auto',
         },
         iconSheet: {
             color: PXBColors.black[900],
@@ -65,15 +65,15 @@ const useStyles = makeStyles((theme: Theme) =>
     })
 );
 
-const instructionLinks = [
-    'https://github.com/pxblue/icons',
-    'https://www.npmjs.com/package/@pxblue/icons-svg',
-    'https://www.npmjs.com/package/@pxblue/icons-mui',
-    'https://material-ui.com/components/icons/#svg-icons',
-    'https://material-ui.com/components/icons/#font-icons',
-    'https://material.angular.io/components/icon/overview#font-icons-with-ligatures',
-    'https://material.angular.io/components/icon/overview#svg-icons',
-];
+const instructionLinks = {
+    icons: 'https://github.com/pxblue/icons',
+    iconsSvg: 'https://www.npmjs.com/package/@pxblue/icons-svg',
+    iconsMui: 'https://www.npmjs.com/package/@pxblue/icons-mui',
+    reactSvg: 'https://material-ui.com/components/icons/#svg-icons',
+    reactFont: 'https://material-ui.com/components/icons/#font-icons',
+    angularFont: 'https://material.angular.io/components/icon/overview#font-icons-with-ligatures',
+    angularSvg: 'https://material.angular.io/components/icon/overview#svg-icons',
+};
 
 const getIconFile = (iconName: string): DetailedIcon | -1 => {
     for (let i = 0; i < meta.icons.length; i++) {
@@ -112,14 +112,14 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                             {isMaterial && (
                                 <Typography color={'inherit'} style={{ marginBottom: '10px' }} variant="subtitle2">
                                     View detailed usage and installation instructions for{' '}
-                                    <ExternalLink href={instructionLinks[4]}>React</ExternalLink> and{' '}
-                                    <ExternalLink href={instructionLinks[5]}>Angular</ExternalLink>.
+                                    <ExternalLink href={instructionLinks.reactFont}>React</ExternalLink> and{' '}
+                                    <ExternalLink href={instructionLinks.angularFont}>Angular</ExternalLink>.
                                 </Typography>
                             )}
                             {!isMaterial && (
                                 <Typography color={'inherit'} style={{ marginBottom: '10px' }} variant="subtitle2">
                                     For detailed usage and installation instructions, visit our{' '}
-                                    <ExternalLink href={instructionLinks[0]}>GitHub</ExternalLink>.
+                                    <ExternalLink href={instructionLinks.icons}>GitHub</ExternalLink>.
                                 </Typography>
                             )}
                             <Typography color={'inherit'} variant="subtitle2">
@@ -138,6 +138,13 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                             </Typography>
                             {!isMaterial && <pre>{`<i class="pxb-${name}"></i>`}</pre>}
                             {isMaterial && <pre>{`<i class="${getSnakeCase(name)}"></i>`}</pre>}
+
+                            <Typography color={'inherit'} variant="subtitle2">
+                                React Native
+                            </Typography>
+                            <Typography color={'inherit'} variant="subtitle2">
+                                For React Native applications, the preferred approach is to use SVG icons.
+                            </Typography>
                         </>
                     );
                 case 1:
@@ -146,14 +153,14 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                             {isMaterial && (
                                 <Typography color={'inherit'} style={{ marginBottom: '10px' }} variant="subtitle2">
                                     View detailed usage and installation instructions for{' '}
-                                    <ExternalLink href={instructionLinks[3]}>React</ExternalLink> and{' '}
-                                    <ExternalLink href={instructionLinks[6]}>Angular</ExternalLink>.
+                                    <ExternalLink href={instructionLinks.reactSvg}>React</ExternalLink> and{' '}
+                                    <ExternalLink href={instructionLinks.angularSvg}>Angular</ExternalLink>.
                                 </Typography>
                             )}
                             {!isMaterial && (
                                 <Typography color={'inherit'} style={{ marginBottom: '10px' }} variant="subtitle2">
                                     For detailed usage and installation instructions, visit our{' '}
-                                    <ExternalLink href={instructionLinks[1]}>GitHub</ExternalLink>.
+                                    <ExternalLink href={instructionLinks.iconsSvg}>GitHub</ExternalLink>.
                                 </Typography>
                             )}
                             <Typography color={'inherit'} variant="subtitle2">
@@ -178,6 +185,24 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                             </Typography>
                             {!isMaterial && <pre>{`<mat-icon svgIcon="${name}"></mat-icon>`}</pre>}
                             {isMaterial && <pre>{`<mat-icon>${getSnakeCase(name)}</mat-icon>`}</pre>}
+
+                            <Typography color={'inherit'} variant="subtitle2">
+                                React Native
+                            </Typography>
+                            {!isMaterial && (
+                                <pre>
+                                    {`import ${getMuiIconName(name)} from '@pxblue/icons-svg/${name}.svg';`}
+                                    <br />
+                                    {`const myIcon = <${getMuiIconName(name)} />`}
+                                </pre>
+                            )}
+                            {isMaterial && (
+                                <pre>
+                                    {`import Icon from 'react-native-vector-icons/MaterialIcons';`}
+                                    <br />
+                                    {`const myIcon = <Icon name="${getKebabCase(name)}"/>;`}
+                                </pre>
+                            )}
                         </>
                     );
                 case 2:
@@ -186,7 +211,7 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                             {!isMaterial && (
                                 <Typography color={'inherit'} style={{ marginBottom: '10px' }} variant="subtitle2">
                                     For detailed usage and installation instructions, visit our{' '}
-                                    <ExternalLink href={instructionLinks[2]}>GitHub</ExternalLink>.
+                                    <ExternalLink href={instructionLinks.iconsMui}>GitHub</ExternalLink>.
                                 </Typography>
                             )}
                             <Typography color={'inherit'} variant="subtitle2">
@@ -198,15 +223,10 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                                 {`<${getMuiIconName(name)}Icon></${getMuiIconName(name)}Icon>`}
                             </pre>
                             <Typography color={'inherit'} variant="subtitle2">
-                                Angular
+                                Angular / React Native
                             </Typography>
                             <Typography color={'inherit'} variant="subtitle2">
-                                Icon components are intended for use only in React applications. For a way to link svg
-                                icons for use in Angular applications, see{' '}
-                                <ExternalLink href={'https://github.com/pxblue/icons/tree/master/svg#angular-1'}>
-                                    @pxblue/icons
-                                </ExternalLink>
-                                .
+                                Icon components are intended for use only in React (web) applications.
                             </Typography>
                         </>
                     );
@@ -239,7 +259,7 @@ export const IconMenu: React.FC<IconMenuProps> = (props): JSX.Element => {
                     return null;
             }
         },
-        [iconData]
+        [iconData, name]
     );
 
     return (

--- a/src/app/components/icons/IconMenu.tsx
+++ b/src/app/components/icons/IconMenu.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme: Theme) =>
             left: 0,
             right: 0,
             bottom: 0,
-            zIndex: 2,
+            zIndex: 1200,
             position: 'fixed',
             marginLeft: 'auto',
             marginRight: 'auto',

--- a/src/app/hooks/useQueryString.tsx
+++ b/src/app/hooks/useQueryString.tsx
@@ -1,0 +1,21 @@
+import { useLocation } from 'react-router-dom';
+
+type SearchParams = {
+    [key: string]: string;
+};
+export const useQueryString = (): SearchParams => {
+    const { search } = useLocation();
+    let noQuestion = search;
+    if (noQuestion.startsWith('?')) noQuestion = noQuestion.substr(1);
+
+    const params = noQuestion.split('&');
+    const ret: SearchParams = {};
+
+    params.forEach((param) => {
+        const keyVal = param.split('=', 2);
+        if (keyVal.length > 1) {
+            ret[keyVal[0]] = decodeURI(keyVal[1]);
+        }
+    });
+    return ret;
+};

--- a/src/app/shared/utilities.tsx
+++ b/src/app/shared/utilities.tsx
@@ -4,6 +4,12 @@ export const getSnakeCase = (str: string): string =>
         .toLowerCase()
         .substr(1);
 
+export const getKebabCase = (str: string): string =>
+    str
+        .replace(/[A-Z]/g, '-$&')
+        .toLowerCase()
+        .substr(1);
+
 export const unCamelCase = (val: string): string =>
     val
         .replace(/([a-z0-9])([A-Z])/g, '$1 $2')


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #150.
Fixes #159. 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Fix the overflow on the icon bottom sheet
- Use query string to deep link to icons
- Update the address bar when user selects an icon
- Automatically expand the appropriate group if the user deep links to an icon
- Add React Native instructions to bottom sheet
- Fix some minor bugs

You can deep link to icons by going to:
https://pxblue.github.io/style/iconography?icon=IconName

You can prepopulate the search field by going to:
https://pxblue.github.io/style/iconography?search=Search%20Query
