### PR TITLE
Add prerelease and deferred tags for roadmap

### DIFF
--- a/src/__types__/index.ts
+++ b/src/__types__/index.ts
@@ -20,7 +20,7 @@ export type MatIconList = {
     [key: string]: (props: SvgIconProps) => JSX.Element;
 };
 
-export type Status = 'backlog' | 'in-progress' | 'finished';
+export type Status = 'backlog' | 'in-progress' | 'pre-release' | 'finished';
 export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';
 
 export type RoadmapItem = {

--- a/src/__types__/index.ts
+++ b/src/__types__/index.ts
@@ -20,7 +20,7 @@ export type MatIconList = {
     [key: string]: (props: SvgIconProps) => JSX.Element;
 };
 
-export type Status = 'backlog' | 'in-progress' | 'pre-release' | 'finished';
+export type Status = 'backlog' | 'in-progress' | 'pre-release' | 'deferred' | 'finished';
 export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';
 
 export type RoadmapItem = {

--- a/src/app/pages/Roadmap.tsx
+++ b/src/app/pages/Roadmap.tsx
@@ -78,8 +78,10 @@ const getStatusColor = (status: Status): PXBlueColor | undefined => {
     switch (status) {
         case 'finished':
             return Colors.green;
-        case 'in-progress':
+        case 'in-progress': 
             return Colors.blue;
+        case 'pre-release':
+            return Colors.purple;
         case 'backlog':
         default:
             return undefined;

--- a/src/app/pages/Roadmap.tsx
+++ b/src/app/pages/Roadmap.tsx
@@ -78,10 +78,12 @@ const getStatusColor = (status: Status): PXBlueColor | undefined => {
     switch (status) {
         case 'finished':
             return Colors.green;
-        case 'in-progress': 
+        case 'in-progress':
             return Colors.blue;
         case 'pre-release':
             return Colors.purple;
+        case 'deferred':
+            return Colors.orange;
         case 'backlog':
         default:
             return undefined;


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Add another roadmap status for "pre-release"
    - Shows a purple ListItemTag
- Add another roadmap status for 'deferred'
    - Shows an orange ListItemTag
