### PR TITLE
Escape asterisk character

### DIFF
--- a/src/docs/patterns/forms.mdx
+++ b/src/docs/patterns/forms.mdx
@@ -21,7 +21,7 @@ When using a mixture of optional and required fields in a form, the inputs shoul
 
 If most of the fields are required, you should call out the fields that are optional. These fields should be labeled with an appropriate descriptor, followed by "optional" in parentheses.
 
-Conversely, if most of your fields are optional, you should only call out the required fields. These should be identified by an asterisk (_) after the field label. There should be a descriptor nearby that indicates that a _ means the field is required.
+Conversely, if most of your fields are optional, you should only call out the required fields. These should be identified by an asterisk (\*) after the field label. There should be a descriptor nearby that indicates that a \* means the field is required.
 
 ## Form Field Requirements
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #197.

Prettier converted a lone asterisk to underscore a while back. This switches it back and escapes it

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Switch asterisk back to asterisk
- Escape the asterisk
