### PR TITLE
Add ability to deep link to search results

### DIFF
--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -200,7 +200,7 @@ export const IconBrowser: React.FC = (): JSX.Element => {
     const location = useLocation();
     const query = useQueryString();
 
-    const [search, setSearch] = useState<string>(() => query.search || '');
+    const [search, setSearch] = useState<string>(() => query.iconSearch || '');
     const [hideLetterGroups, setHideLetterGroups] = useState<LetterGroups>(() => {
         if (query.icon) {
             return { [query.icon.charAt(0).toUpperCase()]: true };

--- a/src/app/hooks/usePrevious.tsx
+++ b/src/app/hooks/usePrevious.tsx
@@ -1,0 +1,15 @@
+import { useRef, useEffect } from 'react';
+
+export const usePrevious = <T extends {}>(value: T): T | undefined => {
+    // The ref object is a generic container whose current property is mutable ...
+    // ... and can hold any value, similar to an instance property on a class
+    const ref = useRef<T>();
+
+    // Store current value in ref
+    useEffect(() => {
+        ref.current = value;
+    }, [value]); // Only re-run if value changes
+
+    // Return previous value (happens before update in useEffect above)
+    return ref.current;
+};


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #190.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Parse URL to deep link into search `.....?search=<searchquery>`
- Handle loading results based strictly on the URL
- Ability to go forward and back (browser) through search results correctly
