### PR TITLE
Center input text in searchbar

### DIFF
--- a/src/app/pages/SearchBar.tsx
+++ b/src/app/pages/SearchBar.tsx
@@ -216,7 +216,7 @@ export const SearchBar: React.FC<SearchbarProps> = (props) => {
                 style={{ zIndex: 1001 }}
                 {...props}
             >
-                <Toolbar style={{ display: 'flex' }}>
+                <Toolbar style={{ display: 'flex' }} id="search-bar">
                     {searchActive && ( // to allow autofocus
                         <TextField
                             className={classes.searchfield}

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,10 @@ q:after {
     content: none;
 }
 
+#search-bar input {
+    padding: 0;
+}
+
 blockquote > p:last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #195 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Search bar text on IOS was off-centered, this fix removes the unnecessary default padding from the MUIInput field

