### PR TITLE
Show outlined progress icons

### DIFF
--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -113,9 +113,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         },
     },
     hideIconsLabel: {
-        display: 'inline-block',
-        float: 'right',
-        paddingRight: theme.spacing(3),
+        justifyContent: 'flex-end',
     },
     iconCard: {
         margin: '0 15px 25px 15px',
@@ -258,13 +256,13 @@ export const IconBrowser: React.FC = (): JSX.Element => {
                         </div>
                     </Toolbar>
                 </AppBar>
-                <div className={classes.hideIconsLabel}>
+                <Toolbar className={classes.hideIconsLabel}>
                     <FormControlLabel
                         control={<Checkbox color="primary" onClick={(): void => setFilterMaterial(!filterMaterial)} />}
                         label="Hide Material Icons"
                         labelPlacement="start"
                     />
-                </div>
+                </Toolbar>
                 <div style={{ padding: '24px' }}>
                     {Object.keys(groupIconList(iconList))
                         .sort()

--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -256,14 +256,14 @@ export const IconBrowser: React.FC = (): JSX.Element => {
                         </div>
                     </Toolbar>
                 </AppBar>
-                <Toolbar className={classes.hideIconsLabel}>
+                <Toolbar className={classes.hideIconsLabel} variant={'dense'}>
                     <FormControlLabel
                         control={<Checkbox color="primary" onClick={(): void => setFilterMaterial(!filterMaterial)} />}
                         label="Hide Material Icons"
                         labelPlacement="start"
                     />
                 </Toolbar>
-                <div style={{ padding: '24px' }}>
+                <div style={{ padding: '0 24px 24px' }}>
                     {Object.keys(groupIconList(iconList))
                         .sort()
                         .map((letterGroup: string) => {

--- a/src/app/components/icons/ProgressIconCard.tsx
+++ b/src/app/components/icons/ProgressIconCard.tsx
@@ -36,15 +36,15 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                     </Typography>
                 </Toolbar>
             </AppBar>
-            <Toolbar style={{ justifyContent: 'flex-end' }}>
+            <Toolbar style={{ justifyContent: 'flex-end' }} variant={'dense'}>
                 <FormControlLabel
                     control={<Checkbox color="primary" onClick={(): void => setIsOutlined(!isOutlined)} />}
                     checked={isOutlined}
-                    label={'View Outlined Icon'}
+                    label={'View Outlined Icons'}
                     labelPlacement={'start'}
                 />
             </Toolbar>
-            <div style={{ textAlign: 'center', padding: '24px' }}>
+            <div style={{ textAlign: 'center', padding: '0 24px 24px' }}>
                 <Typography variant={'h6'}>{'Battery'}</Typography>
                 {colors.map((key, index) => (
                     <Progress.Battery

--- a/src/app/components/icons/ProgressIconCard.tsx
+++ b/src/app/components/icons/ProgressIconCard.tsx
@@ -5,7 +5,7 @@ import * as Progress from '@pxblue/react-progress-icons';
 import * as PXBColors from '@pxblue/colors';
 
 // Material-UI Components
-import { Typography, AppBar, Paper, Toolbar, makeStyles } from '@material-ui/core';
+import { Typography, AppBar, Paper, Toolbar, makeStyles, Switch } from '@material-ui/core';
 import { PXBlueColor } from '@pxblue/types';
 
 const size = 48;
@@ -25,6 +25,12 @@ const useStyles = makeStyles(() => ({
 export const ProgressIconCard: React.FC = (): JSX.Element => {
     const classes = useStyles();
 
+    const [isOutlined, setIsOutlined] = React.useState(false);
+
+    const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        setIsOutlined(event.target.checked);
+    };
+
     return (
         <Paper elevation={4}>
             <AppBar position="static" color="primary" classes={{ root: classes.header }}>
@@ -34,6 +40,17 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                     </Typography>
                 </Toolbar>
             </AppBar>
+            <Toolbar>
+                <Switch
+                    checked={isOutlined}
+                    inputProps={{ 'aria-label': 'View Outlined Icons' }}
+                    onChange={onChangeSwitch}
+                />
+
+                <Typography variant="body1" color="inherit" noWrap style={{ marginLeft: 8 }}>
+                    View Outlined Icon
+                </Typography>
+            </Toolbar>
             <div style={{ textAlign: 'center', padding: '24px' }}>
                 <Typography variant={'h6'}>{'Battery'}</Typography>
                 {colors.map((key, index) => (
@@ -42,6 +59,7 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                         percent={(index + 1) * 10}
                         size={size}
                         color={colorSet[key][weight]}
+                        outlined={isOutlined}
                     />
                 ))}
                 <br />
@@ -52,6 +70,7 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                         percent={(index + 1) * 10}
                         size={size}
                         color={colorSet[key][weight]}
+                        outlined={isOutlined}
                     />
                 ))}
                 <br />
@@ -63,6 +82,7 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                         size={size}
                         color={colorSet[key][weight]}
                         ring={4}
+                        outlined={isOutlined}
                     />
                 ))}
                 <br />
@@ -73,6 +93,7 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                         percent={(index + 1) * 10}
                         size={size}
                         color={colorSet[key][weight]}
+                        outlined={isOutlined}
                     />
                 ))}
             </div>

--- a/src/app/components/icons/ProgressIconCard.tsx
+++ b/src/app/components/icons/ProgressIconCard.tsx
@@ -5,7 +5,7 @@ import * as Progress from '@pxblue/react-progress-icons';
 import * as PXBColors from '@pxblue/colors';
 
 // Material-UI Components
-import { Typography, AppBar, Paper, Toolbar, makeStyles, Switch } from '@material-ui/core';
+import { Typography, AppBar, Paper, Toolbar, makeStyles, FormControlLabel, Checkbox } from '@material-ui/core';
 import { PXBlueColor } from '@pxblue/types';
 
 const size = 48;
@@ -27,10 +27,6 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
 
     const [isOutlined, setIsOutlined] = React.useState(false);
 
-    const onChangeSwitch = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        setIsOutlined(event.target.checked);
-    };
-
     return (
         <Paper elevation={4}>
             <AppBar position="static" color="primary" classes={{ root: classes.header }}>
@@ -40,16 +36,13 @@ export const ProgressIconCard: React.FC = (): JSX.Element => {
                     </Typography>
                 </Toolbar>
             </AppBar>
-            <Toolbar>
-                <Switch
+            <Toolbar style={{ justifyContent: 'flex-end' }}>
+                <FormControlLabel
+                    control={<Checkbox color="primary" onClick={(): void => setIsOutlined(!isOutlined)} />}
                     checked={isOutlined}
-                    inputProps={{ 'aria-label': 'View Outlined Icons' }}
-                    onChange={onChangeSwitch}
+                    label={'View Outlined Icon'}
+                    labelPlacement={'start'}
                 />
-
-                <Typography variant="body1" color="inherit" noWrap style={{ marginLeft: 8 }}>
-                    View Outlined Icon
-                </Typography>
             </Toolbar>
             <div style={{ textAlign: 'center', padding: '24px' }}>
                 <Typography variant={'h6'}>{'Battery'}</Typography>


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added a little switch in the progress icon card to view the outlined icons
<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/8997218/89819301-2f276e00-db19-11ea-8e6b-e081beb1949d.png)
