### PR TITLE
Optimize the icon loading logic for faster rendering

### DIFF
--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -58,12 +58,7 @@ for (const ico of pxbMetadata.icons) {
     pxbMetaObject[getMuiIconName(ico.filename)] = ico;
 }
 
-// eslint-disable-next-line
-console.log('outside component');
-
 const loadIcons = (): void => {
-    // eslint-disable-next-line
-    console.log('loading icons');
     Object.keys(MuiIcons).map((iconKey) => {
         let type: MuiIconClass;
         if (iconKey.includes('Outlined')) {

--- a/src/app/components/icons/IconGrid.tsx
+++ b/src/app/components/icons/IconGrid.tsx
@@ -44,35 +44,40 @@ const Icons: React.FC<IconGridProps> = (props) => {
 
     return (
         <Grid container spacing={2}>
-            {icons.map((icon) => {
-                const isSelected = selected && selected.name === icon.name && selected.isMaterial === icon.isMaterial;
-                const iconDisplayName = unCamelCase(icon.name);
-                return (
-                    <Grid
-                        item
-                        xs={4}
-                        sm={2}
-                        md={3}
-                        lg={2}
-                        key={`${icon.name}_${icon.isMaterial ? 'material' : 'pxblue'}`}
-                        onClick={onIconSelected}
-                        data-iconid={`${icon.name}-${icon.isMaterial ? 'material' : 'pxb'}`}
-                    >
-                        <div className={clsx(classes.wrapper, { [classes.selected]: isSelected })}>
-                            <icon.Icon
-                                style={{ fontSize: iconDisplayName.toLocaleLowerCase().includes('eaton') ? 24 : 36 }}
-                            />
-                            <Typography
-                                variant="subtitle2"
-                                className={classes.label}
-                                color={isSelected ? 'primary' : 'textPrimary'}
-                            >
-                                {iconDisplayName}
-                            </Typography>
-                        </div>
-                    </Grid>
-                );
-            })}
+            {icons
+                .sort((iconA, iconB) => (iconA.name < iconB.name ? -1 : 1))
+                .map((icon) => {
+                    const isSelected =
+                        selected && selected.name === icon.name && selected.isMaterial === icon.isMaterial;
+                    const iconDisplayName = unCamelCase(icon.name);
+                    return (
+                        <Grid
+                            item
+                            xs={4}
+                            sm={2}
+                            md={3}
+                            lg={2}
+                            key={`${icon.name}_${icon.isMaterial ? 'material' : 'pxblue'}`}
+                            onClick={onIconSelected}
+                            data-iconid={`${icon.name}-${icon.isMaterial ? 'material' : 'pxb'}`}
+                        >
+                            <div className={clsx(classes.wrapper, { [classes.selected]: isSelected })}>
+                                <icon.Icon
+                                    style={{
+                                        fontSize: iconDisplayName.toLocaleLowerCase().includes('eaton') ? 24 : 36,
+                                    }}
+                                />
+                                <Typography
+                                    variant="subtitle2"
+                                    className={classes.label}
+                                    color={isSelected ? 'primary' : 'textPrimary'}
+                                >
+                                    {iconDisplayName}
+                                </Typography>
+                            </div>
+                        </Grid>
+                    );
+                })}
         </Grid>
     );
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Don't run the icon loading logic when loading the landing page
- Load the icons after the first render of the iconography page
- Convert the metadata arrays into objects for faster search/indexing