### PR TITLE
Fix width changing per framework on resource page

### DIFF
--- a/src/app/pages/Resources.tsx
+++ b/src/app/pages/Resources.tsx
@@ -84,7 +84,7 @@ export const Resources: React.FC = (): JSX.Element => {
             </AppBar>
 
             {/* First expander */}
-            <PageContent>
+            <PageContent style={{ width: '100%' }}>
                 {resources.map(
                     (bucket, bIndex) =>
                         (!bucket.applies ||


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #316 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Adds style to prevent resource page from having dynamic width for each framework tab.


<!-- Include screenshots if they will help illustrate the changes in this PR -->
Hosted here: https://pxblue-docit.web.app/resources
