### PR TITLE
Fix the query regex problem causing safari trouble

### DIFF
--- a/src/app/pages/SearchBar.tsx
+++ b/src/app/pages/SearchBar.tsx
@@ -103,7 +103,7 @@ export const SearchBar: React.FC<SearchbarProps> = (props) => {
     const pushHistory = useCallback(
         (searchQuery: string) => {
             // match everything preceded by "&search=" and either end directly or is followed by a "&"
-            const currentQueryString = location.search.match(/(?<=&search=)[^&]*($|(?=&))/g);
+            const currentQueryString = location.search.match(/&search=[^&]*($|(?=&))/g)?.slice(8);
 
             // only push history when the user is not searching for the exact same string
             if (


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes the thing we talked about in the chat

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Replace the look ahead syntax with some string slicing logic

To test, open up localhost in Safari. 
