### PR TITLE
Make the item round again

### DIFF
--- a/src/app/router/navigationDrawer.tsx
+++ b/src/app/router/navigationDrawer.tsx
@@ -60,6 +60,20 @@ export const NavigationDrawer = (): JSX.Element => {
         return convertedItems;
     }, []);
 
+    const getDrawerNavItemActiveBackgroundColor = useCallback((): string | undefined => {
+        if (activeDrawerFade) {
+            return color(theme.palette.primary.main)
+                .fade(activeDrawerFade)
+                .string();
+        } else if (theme.palette.type === 'light') {
+            return undefined; // use the drawer default
+        }
+        // TODO: remove this logic when we publish the better dark theme
+        return color(theme.palette.primary.main)
+            .fade(0.8)
+            .string();
+    }, [theme, activeDrawerFade]);
+
     useEffect(() => {
         setActiveRoute(location.pathname);
     }, [location.pathname]);
@@ -77,22 +91,14 @@ export const NavigationDrawer = (): JSX.Element => {
             }}
             variant={isMobile || isLandingPage ? 'temporary' : 'permanent'}
             nestedBackgroundColor={theme.palette.type === 'light' ? undefined : Colors.darkBlack[500]}
-            activeItemBackgroundColor={
-                activeDrawerFade
-                    ? color(theme.palette.primary.main)
-                          .fade(activeDrawerFade)
-                          .string()
-                    : theme.palette.type === 'light'
-                    ? undefined
-                    : color(theme.palette.primary.main)
-                          .fade(0.8)
-                          .string()
-            }
+            activeItemBackgroundColor={getDrawerNavItemActiveBackgroundColor()}
             activeItemFontColor={theme.palette.type === 'light' ? undefined : theme.palette.primary.light}
             activeItemIconColor={theme.palette.type === 'light' ? undefined : theme.palette.primary.light}
             itemFontColor={theme.palette.text.primary}
             divider={false}
             activeItem={activeRoute}
+            hidePadding
+            activeItemBackgroundShape={'round'}
         >
             <DrawerHeader
                 icon={<PxblueSmall />}
@@ -126,7 +132,7 @@ export const NavigationDrawer = (): JSX.Element => {
                 }
             />
             <DrawerBody>
-                <DrawerNavGroup hidePadding items={menuItems} />
+                <DrawerNavGroup items={menuItems} />
             </DrawerBody>
             <DrawerFooter>
                 <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -2074,7 +2074,7 @@
   resolved "https://registry.yarnpkg.com/@pxblue/prettier-config/-/prettier-config-1.0.2.tgz#fb00503df6557b66c3d91d43c9101e614c35d2ec"
   integrity sha512-/3cLBoTjZs3kV1ATPA/Sp0tsL7XmlV/b8HW/qt0jqR/uP5+cdXL2YIhMXQngLRa7PhpSkEiRIYK5sl0rKsXTUg==
 
-"@pxblue/react-components@5.0.0":
+"@pxblue/react-components@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@pxblue/react-components/-/react-components-5.0.0.tgz#f245e51de9c0bf2403ee12769aff87dd0875a3ec"
   integrity sha512-HrZxrV8lWj/09m/pjtTsoo2z/RUBxKj3gu//vqwL3LtN+i3FeTl9guvDbJIHpLWFxHfBJ/AVgOgyIjWAWqRJAA==


### PR DESCRIPTION
I find the square activeBackgroundShape really awkward when nested items are involved — can be hard to see which one is getting selected. 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- useCallback to calculate the background color
- changed `activeItemBackgroundShape` to `round`

### Unrelated Stuff
I have another branch `feature/condensed-drawer` that plays around with the condensed drawer item variant, according to an earlier proposed drawer design. I know the design is not "final-final" yet, but as more and more pages are getting added to docit, I think it's time for docit to have a condensed drawer.
![image](https://user-images.githubusercontent.com/8997218/108924614-f0ff2100-7608-11eb-9c81-02e7b6f45005.png)

