### PR TITLE
Default to showing r19 until we have planned r20

### DIFF
--- a/src/__configuration__/roadmap/index.ts
+++ b/src/__configuration__/roadmap/index.ts
@@ -1,22 +1,22 @@
 import { Quarter, Release } from '../../__types__';
 
-export const CURRENT_RELEASE: Release = 'R20';
+export const CURRENT_RELEASE: Release = 'R19';
 
 export const AVAILABLE_RELEASES: Array<{
     name: Release;
     year: number;
     quarter: Quarter;
 }> = [
-    {
-        name: 'R21',
-        year: 2021,
-        quarter: 'Q3',
-    },
-    {
-        name: 'R20',
-        year: 2021,
-        quarter: 'Q2',
-    },
+    // {
+    //     name: 'R21',
+    //     year: 2021,
+    //     quarter: 'Q3',
+    // },
+    // {
+    //     name: 'R20',
+    //     year: 2021,
+    //     quarter: 'Q2',
+    // },
     {
         name: 'R19',
         year: 2021,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Default to showing only R19 roadmap since R20 and R21 are empty