### PR TITLE
Add attr page to community home page

### DIFF
--- a/src/__configuration__/community/index.tsx
+++ b/src/__configuration__/community/index.tsx
@@ -75,7 +75,7 @@ export const links = [
             </span>
         ),
         background: {
-            color: BrandingColors.navy[300],
+            color: BrandingColors.pine[300],
         },
     },
     {
@@ -88,7 +88,7 @@ export const links = [
             </span>
         ),
         background: {
-            color: BrandingColors.pine[300],
+            color: BrandingColors.navy[300],
         },
     },
     {

--- a/src/__configuration__/community/index.tsx
+++ b/src/__configuration__/community/index.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { Gavel, BugReport, EmojiObjects, QuestionAnswer, Group, Drafts, ImportExport } from '@material-ui/icons';
+import {
+    Gavel,
+    BugReport,
+    EmojiObjects,
+    QuestionAnswer,
+    Group,
+    Drafts,
+    ImportExport,
+    Person,
+} from '@material-ui/icons';
 import * as Colors from '@pxblue/colors';
 import * as BrandingColors from '@pxblue/colors-branding';
 
@@ -9,7 +18,7 @@ export const links = [
         url: '/community/license',
         description: `Learn about the open source license under which PX Blue is made available.`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <Gavel fontSize={'inherit'} color={'inherit'} />
             </span>
         ),
@@ -22,7 +31,7 @@ export const links = [
         url: '/community/innersourcing',
         description: `Help improve PX Blue for others by sharing your work with the larger community.`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <ImportExport fontSize={'inherit'} color={'inherit'} />
             </span>
         ),
@@ -35,7 +44,7 @@ export const links = [
         url: '/community/bugs',
         description: `Found an issue? Let us know so we can fix it!.`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <BugReport fontSize={'inherit'} color={'inherit'} />
             </span>
         ),
@@ -48,7 +57,7 @@ export const links = [
         url: '/community/features',
         description: `Have an idea for a new addition to PX Blue? Tell us about it!`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <EmojiObjects fontSize={'inherit'} color={'inherit'} />
             </span>
         ),
@@ -61,8 +70,21 @@ export const links = [
         url: '/community/faq',
         description: `Read answers to common questions about using PX Blue.`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <QuestionAnswer fontSize={'inherit'} color={'inherit'} />
+            </span>
+        ),
+        background: {
+            color: BrandingColors.navy[300],
+        },
+    },
+    {
+        title: 'Attributions',
+        url: '/community/attributions',
+        description: `Attributions to assets used on this website.`,
+        image: (
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
+                <Person fontSize={'inherit'} color={'inherit'} />
             </span>
         ),
         background: {
@@ -74,7 +96,7 @@ export const links = [
         url: '/community/our-team',
         description: `Meet the people behind PX Blue and learn what makes us tick.`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <Group fontSize={'inherit'} color={'inherit'} />
             </span>
         ),
@@ -87,7 +109,7 @@ export const links = [
         url: '/community/contactus',
         description: `We love hearing from you! Feel free to contact us any time to talk about PX Blue or your projects.`,
         image: (
-            <span style={{ fontSize: 120, color: 'white' }}>
+            <span style={{ fontSize: 120, color: 'white', display: 'flex' }}>
                 <Drafts fontSize={'inherit'} color={'inherit'} />
             </span>
         ),


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add attribution page to `/community`
  - There used to be an icon for "attributions" but Material Design took it away. Feel free to suggest some other icon.
- Adjust icons' vertical alignment

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Before:
![image](https://user-images.githubusercontent.com/8997218/114461709-11cb0800-9bb0-11eb-9caf-5eadd7cab42a.png)
After:
![image](https://user-images.githubusercontent.com/8997218/114461893-4e96ff00-9bb0-11eb-97ac-9bbe47b612b2.png)
