### PR TITLE
Add copy on click functionality

### DIFF
--- a/src/__configuration__/markdown/markdown.css
+++ b/src/__configuration__/markdown/markdown.css
@@ -17,3 +17,9 @@
 .headline:not(:first-child) .MuiIconButton-root:active .MuiSvgIcon-root {
     opacity: 0.5;
 }
+
+@media (hover: none) {
+    .headline:not(:first-child) .headline-text .MuiSvgIcon-root {
+        opacity: 0.25;
+    }
+}

--- a/src/__configuration__/markdown/markdown.css
+++ b/src/__configuration__/markdown/markdown.css
@@ -8,15 +8,12 @@
     margin-top: 96px;
 }
 
-.headline:not(:first-child):hover {
-    cursor: pointer;
-}
-.headline:not(:first-child) .MuiSvgIcon-root {
+.headline:not(:first-child) .headline-text .MuiSvgIcon-root {
     opacity: 0;
 }
-.headline:not(:first-child):hover .MuiSvgIcon-root {
+.headline:not(:first-child) .headline-text:hover .MuiSvgIcon-root {
     opacity: 1;
 }
-.headline:not(:first-child):active .MuiSvgIcon-root {
+.headline:not(:first-child) .MuiIconButton-root:active .MuiSvgIcon-root {
     opacity: 0.5;
 }

--- a/src/__configuration__/markdown/markdown.css
+++ b/src/__configuration__/markdown/markdown.css
@@ -12,6 +12,9 @@
     opacity: 0;
 }
 .headline:not(:first-child) .headline-text:hover .MuiSvgIcon-root {
+    opacity: 0.25;
+}
+.headline:not(:first-child) .MuiIconButton-root:hover .MuiSvgIcon-root {
     opacity: 1;
 }
 .headline:not(:first-child) .MuiIconButton-root:active .MuiSvgIcon-root {

--- a/src/__configuration__/markdown/markdownMapping.tsx
+++ b/src/__configuration__/markdown/markdownMapping.tsx
@@ -94,7 +94,7 @@ const Headline: React.FC<Headline> = ({
                         copyTextToClipboard(`${window.location.origin}${window.location.pathname}#${hash}`);
                         setOnCopy(true);
                     }}
-                    style={{ position: 'relative', right: -8 }}
+                    style={{ marginLeft: 8 }}
                     size={'small'}
                     color={'primary'}
                 >

--- a/src/__configuration__/markdown/markdownMapping.tsx
+++ b/src/__configuration__/markdown/markdownMapping.tsx
@@ -9,6 +9,7 @@ import {
     Theme,
     createStyles,
     useTheme,
+    IconButton,
 } from '@material-ui/core';
 import { Link as LinkIcon } from '@material-ui/icons';
 import { Link, LinkProps } from 'react-router-dom';
@@ -75,10 +76,6 @@ const Headline: React.FC<Headline> = ({
     return (
         <div
             className={clsx(className, 'headline')}
-            onClick={(): void => {
-                copyTextToClipboard(`${window.location.origin}${window.location.pathname}#${hash}`);
-                setOnCopy(true);
-            }}
             {...otherDivProps}
             style={{ ...REGULAR_WIDTH_STYLE, ...otherDivProps.style }}
         >
@@ -88,16 +85,21 @@ const Headline: React.FC<Headline> = ({
                 color={'primary'}
                 component={'span'}
                 {...otherTypographyProps}
-                style={{ hyphens: 'auto', display: 'flex', ...otherTypographyProps.style }}
+                className={'headline-text'}
+                style={{ hyphens: 'auto', ...otherTypographyProps.style }}
             >
                 {otherTypographyProps.children}
-                <LinkIcon
-                    color={'action'}
-                    style={{ marginLeft: 16, alignSelf: 'center' }}
-                    titleAccess={'copy to clipboard'}
-                    fontSize={'inherit'}
-                    {...otherSvgIconProps}
-                />
+                <IconButton
+                    onClick={(): void => {
+                        copyTextToClipboard(`${window.location.origin}${window.location.pathname}#${hash}`);
+                        setOnCopy(true);
+                    }}
+                    style={{ position: 'relative', right: -8 }}
+                    size={'small'}
+                    color={'primary'}
+                >
+                    <LinkIcon titleAccess={'copy to clipboard'} {...otherSvgIconProps} />
+                </IconButton>
             </Typography>
             {onCopy && (
                 <Snackbar

--- a/src/app/components/colors/Colors.tsx
+++ b/src/app/components/colors/Colors.tsx
@@ -1,13 +1,14 @@
-import React, { ComponentProps } from 'react';
+import React, { ComponentProps, useCallback, useState } from 'react';
 import { Typography, makeStyles, createStyles, Theme } from '@material-ui/core';
-import { Bookmark } from '@material-ui/icons';
+import { Bookmark, Check } from '@material-ui/icons';
 import * as Colors from '@pxblue/colors';
 import { AppState } from '../../redux/reducers';
+import { copyTextToClipboard } from '../../shared';
 import { useSelector } from 'react-redux';
 import { PXBlueColor } from '@pxblue/types';
+import colorModule from 'color';
 
-const getColorLabel = (color: string): JSX.Element | null => {
-    const format = useSelector((state: AppState) => state.app.colorFormat);
+const getColorLabel = (color: string, format: 'rgb' | 'hex'): JSX.Element | null => {
     if (format === 'hex') {
         return <span>{color}</span>;
     }
@@ -51,6 +52,11 @@ const useStyles = makeStyles((theme: Theme) =>
         label: {
             background: theme.palette.background.paper,
             padding: theme.spacing(1),
+            position: 'relative',
+            '&:hover $copyOnHoverButton': {
+                display: 'flex',
+                cursor: 'pointer',
+            },
         },
         paletteWrapper: {
             width: '100%',
@@ -61,12 +67,37 @@ const useStyles = makeStyles((theme: Theme) =>
                 WebkitJustifyContent: 'space-between',
             },
         },
+        copyOnHoverButton: {
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            display: 'none',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: colorModule(theme.palette.background.paper).alpha(0.9).string(),
+        },
     })
 );
 
 export const ColorSwatch: React.FC<SwatchProps> = (props): JSX.Element => {
     const classes = useStyles();
     const { color, weight, ...otherProps } = props;
+    const format = useSelector((state: AppState) => state.app.colorFormat);
+
+    const [copied, setCopied] = useState(false);
+
+    const colorLabel = useCallback(() => getColorLabel(color, format), [color, format]);
+
+    const copyColorToClipboard = useCallback(() => {
+        if (format === 'hex') {
+            copyTextToClipboard(color);
+        } else {
+            copyTextToClipboard(colorModule(color).rgb().string());
+        }
+        setCopied(true);
+    }, [color, format]);
 
     return (
         <div {...otherProps}>
@@ -74,9 +105,31 @@ export const ColorSwatch: React.FC<SwatchProps> = (props): JSX.Element => {
                 {props.weight === '500' && <Bookmark className={classes.bookmark} />}
             </div>
             <div className={classes.label}>
+                <div
+                    className={classes.copyOnHoverButton}
+                    onClick={copyColorToClipboard}
+                    onMouseLeave={(): void => {
+                        setCopied(false);
+                    }}
+                >
+                    {!copied ? (
+                        <Typography variant={'caption'} color={'primary'}>
+                            {format === 'hex' ? 'Copy HEX' : 'Copy RGB'}
+                        </Typography>
+                    ) : (
+                        <Typography
+                            variant={'caption'}
+                            color={'textPrimary'}
+                            style={{ display: 'flex', alignItems: 'center' }}
+                        >
+                            Copied
+                            <Check fontSize={'inherit'} />
+                        </Typography>
+                    )}
+                </div>
                 <Typography variant={'subtitle2'} style={{ fontWeight: 600 }}>{`${weight}:`}</Typography>
                 <Typography variant={'caption'} style={{ fontFamily: 'Roboto Mono' }}>
-                    {getColorLabel(color)}
+                    {colorLabel()}
                 </Typography>
             </div>
         </div>


### PR DESCRIPTION
I found myself keep copying & pasting hex code and it annoys me that I cannot do that in one click.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
## Changes proposed in this Pull Request:
- Add a copy-on-click functionality
- Shrink the hover area of those headlines, so that there would be no more unexpected misclicks.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
## Screenshots

### Copy color codes

This works for both hex and rgb.

| default | hover | clicked | your clipboard now is
| - | - | - | - |
| ![image](https://user-images.githubusercontent.com/8997218/116143146-c41ec700-a6a8-11eb-990e-0b7dfae854bc.png) | ![image](https://user-images.githubusercontent.com/8997218/116143159-c97c1180-a6a8-11eb-85ef-1d06190bf009.png) | ![image](https://user-images.githubusercontent.com/8997218/116143178-ced95c00-a6a8-11eb-92b8-725e901794f2.png) |`#004b9e`
| ![image](https://user-images.githubusercontent.com/8997218/116143465-2ed00280-a6a9-11eb-9307-cfc50fb95a73.png) | ![image](https://user-images.githubusercontent.com/8997218/116143486-34c5e380-a6a9-11eb-959a-81825f6a6b6d.png) | ![image](https://user-images.githubusercontent.com/8997218/116143507-3b545b00-a6a9-11eb-97e6-2c916abeb0a6.png) | `rgb(0, 75, 158)`

## Copy headlines
On desktop:
![image](https://user-images.githubusercontent.com/8997218/116148459-efa4b000-a6ae-11eb-9ee0-55f912818dbe.png)

On a touch screen (defined by `@media (hover: none)`), the deeplink icon is always visible with a 0.25 opacity:
![image](https://user-images.githubusercontent.com/8997218/116148628-1f53b800-a6af-11eb-8fe6-d7bef56fcdf6.png)



